### PR TITLE
Serialization Roundtrip Issues

### DIFF
--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -207,7 +207,7 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         # such a value to pollute the cache.
         reserialized = text_type(key)
         if serialized != reserialized:
-            raise InvalidKeyError(cls, "{} -> {}".format(serialized, reserialized))
+            raise InvalidKeyError(cls, u"{} -> {}".format(serialized, reserialized))
 
         cls._cache_pool[serialized] = key
         return key

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -189,13 +189,28 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         # pylint: disable=protected-access
         # load drivers before checking for attr
         cls._drivers()
-        try:
-            namespace, rest = cls._separate_namespace(serialized)
-            return cls.get_namespace_plugin(namespace)._from_string(rest)
-        except InvalidKeyError:
-            if hasattr(cls, 'deprecated_fallback'):
-                return cls.deprecated_fallback._from_deprecated_string(serialized)
-            raise InvalidKeyError(cls, serialized)
+
+        def _parse_with_fallback():
+            """Try to parse as new style key, then fall back to old style."""
+            try:
+                namespace, rest = cls._separate_namespace(serialized)
+                return cls.get_namespace_plugin(namespace)._from_string(rest)
+            except InvalidKeyError:
+                if hasattr(cls, 'deprecated_fallback'):
+                    return cls.deprecated_fallback._from_deprecated_string(serialized)
+                raise InvalidKeyError(cls, serialized)
+
+        key = _parse_with_fallback()
+
+        # We've been bitten by keys that do not re-serialize to the same value
+        # they were parsed from. This is a guard to make sure we never allow
+        # such a value to pollute the cache.
+        reserialized = text_type(key)
+        if serialized != reserialized:
+            raise InvalidKeyError(cls, "{} -> {}".format(serialized, reserialized))
+
+        cls._cache_pool[serialized] = key
+        return key
 
     @classmethod
     def _separate_namespace(cls, serialized):

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -209,7 +209,6 @@ class OpaqueKey(with_metaclass(OpaqueKeyMetaclass)):
         if serialized != reserialized:
             raise InvalidKeyError(cls, u"{} -> {}".format(serialized, reserialized))
 
-        cls._cache_pool[serialized] = key
         return key
 
     @classmethod

--- a/opaque_keys/edx/tests/test_properties.py
+++ b/opaque_keys/edx/tests/test_properties.py
@@ -171,6 +171,11 @@ def perturbed_strings(string_strategy):
     serialized=u'i4x://-/-/-/-@-',
     perturbed=u'/i4x/-/-/-/-@-',
 )
+@example(
+    key_type=UsageKey,
+    serialized=u'i4x://-/-/-/-@-',
+    perturbed=u'i4x://-/-/-/-@-/',
+)
 def test_perturbed_serializations(key_type, serialized, perturbed):
     assume(serialized != perturbed)
 


### PR DESCRIPTION
I reverted the optimizations again in #85 because hypothesis failed a master build on `i4x://-/-/-/-@-/`, which should not have parsed but does. Picking it up again months later, I see that this particular string fails on master as well.

Instead of trying to tweak the regular expression to flag this particular case as invalid, I did a big hammer approach of always doing a serialization roundtrip when calling OpaqueKey.from_string() -- it will now raise an InvalidKeyError whenever a key does not reserialize into the same representation it was parsed from. This fixed the original error, but caused a few other tests to fail, and I wanted to discuss what our desired behavior is here (the "Opaque Key Laws" that @cpennington has talked about codifying in the past).

I haven't measured the performance impact of doing this, and it may not be practical to keep in. But I thought it would raise some interesting examples to talk about.