### PR TITLE
fix: Install pip and pip-tools in upgrade script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ upgrade: ## update the requirements/*.txt files with the latest packages satisfy
 	pip install -qr requirements/pip.txt
 	pip-compile --upgrade --allow-unsafe --rebuild -o requirements/pip.txt requirements/pip.in
 	pip-compile --rebuild --upgrade -o requirements/pip-tools.txt requirements/pip-tools.in
+	pip install -qr requirements/pip.txt
+	pip install -qr requirements/pip-tools.txt
 	pip-compile --rebuild --upgrade -o requirements/base.txt requirements/base.in
 	pip-compile --rebuild --upgrade -o requirements/django.txt requirements/django.in
 	pip-compile --rebuild --upgrade -o requirements/test.txt requirements/test.in

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,5 +8,5 @@ pbr==5.9.0
     # via stevedore
 pymongo==3.12.3
     # via -r requirements/base.in
-stevedore==3.5.0
+stevedore==4.0.0
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -6,13 +6,13 @@
 #
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
-coverage==6.4.1
+coverage==6.4.2
     # via coveralls
 coveralls==3.3.1
     # via -r requirements/ci.in
-distlib==0.3.4
+distlib==0.3.5
     # via virtualenv
 docopt==0.6.2
     # via coveralls
@@ -34,21 +34,19 @@ py==1.11.0
     # via tox
 pyparsing==3.0.9
     # via packaging
-requests==2.28.0
+requests==2.28.1
     # via coveralls
 six==1.16.0
-    # via
-    #   tox
-    #   virtualenv
+    # via tox
 toml==0.10.2
     # via tox
-tox==3.25.0
+tox==3.25.1
     # via
     #   -r requirements/ci.in
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.in
-urllib3==1.26.9
+urllib3==1.26.11
     # via requests
-virtualenv==20.14.1
+virtualenv==20.16.2
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,12 +8,12 @@ alabaster==0.7.12
     # via
     #   -r requirements/doc.txt
     #   sphinx
-astroid==2.11.6
+astroid==2.11.7
     # via
     #   -r requirements/doc.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/doc.txt
     #   hypothesis
@@ -22,16 +22,20 @@ babel==2.10.3
     # via
     #   -r requirements/doc.txt
     #   sphinx
-bleach==5.0.0
+bleach==5.0.1
     # via
     #   -r requirements/doc.txt
     #   readme-renderer
+build==0.8.0
+    # via
+    #   -r requirements/pip-tools.txt
+    #   pip-tools
 certifi==2022.6.15
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
     #   requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
@@ -52,7 +56,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/doc.txt
     #   edx-lint
-coverage[toml]==6.4.1
+coverage[toml]==6.4.2
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
@@ -66,7 +70,7 @@ dill==0.3.5.1
     # via
     #   -r requirements/doc.txt
     #   pylint
-distlib==0.3.4
+distlib==0.3.5
     # via
     #   -r requirements/ci.txt
     #   virtualenv
@@ -74,7 +78,7 @@ docopt==0.6.2
     # via
     #   -r requirements/ci.txt
     #   coveralls
-docutils==0.18.1
+docutils==0.19
     # via
     #   -r requirements/doc.txt
     #   readme-renderer
@@ -97,18 +101,18 @@ filelock==3.7.1
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-hypothesis==6.47.3
+hypothesis==6.53.0
     # via -r requirements/doc.txt
 idna==3.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
     #   requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via
     #   -r requirements/doc.txt
     #   sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via
     #   -r requirements/doc.txt
     #   sphinx
@@ -143,6 +147,8 @@ packaging==21.3
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
+    #   -r requirements/pip-tools.txt
+    #   build
     #   pytest
     #   sphinx
     #   tox
@@ -153,12 +159,12 @@ pbr==5.9.0
 pep517==0.12.0
     # via
     #   -r requirements/pip-tools.txt
-    #   pip-tools
+    #   build
 pep8==1.7.1
     # via
     #   -r requirements/doc.txt
     #   pytest-pep8
-pip-tools==6.6.2
+pip-tools==6.8.0
     # via -r requirements/pip-tools.txt
 platformdirs==2.5.2
     # via
@@ -187,7 +193,7 @@ pygments==2.12.0
     #   -r requirements/doc.txt
     #   readme-renderer
     #   sphinx
-pylint==2.14.3
+pylint==2.14.5
     # via
     #   -r requirements/doc.txt
     #   edx-lint
@@ -214,6 +220,7 @@ pyparsing==3.0.9
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
+    #   -r requirements/pip-tools.txt
     #   packaging
 pytest==5.4.3
     # via
@@ -257,7 +264,7 @@ pyyaml==6.0
     #   code-annotations
 readme-renderer==35.0
     # via -r requirements/doc.txt
-requests==2.28.0
+requests==2.28.1
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
@@ -272,7 +279,6 @@ six==1.16.0
     #   edx-sphinx-theme
     #   pytest-xdist
     #   tox
-    #   virtualenv
 snowballstemmer==2.2.0
     # via
     #   -r requirements/doc.txt
@@ -281,7 +287,7 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/doc.txt
     #   hypothesis
-sphinx==5.0.2
+sphinx==5.1.1
     # via
     #   -r requirements/doc.txt
     #   edx-sphinx-theme
@@ -309,7 +315,7 @@ sphinxcontrib-serializinghtml==1.1.5
     # via
     #   -r requirements/doc.txt
     #   sphinx
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/doc.txt
     #   code-annotations
@@ -327,30 +333,31 @@ tomli==2.0.1
     # via
     #   -r requirements/doc.txt
     #   -r requirements/pip-tools.txt
+    #   build
     #   coverage
     #   pep517
     #   pylint
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/doc.txt
     #   pylint
-tox==3.25.0
+tox==3.25.1
     # via
     #   -r requirements/ci.txt
     #   tox-battery
 tox-battery==0.6.1
     # via -r requirements/ci.txt
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/doc.txt
     #   astroid
     #   pylint
-urllib3==1.26.9
+urllib3==1.26.11
     # via
     #   -r requirements/ci.txt
     #   -r requirements/doc.txt
     #   requests
-virtualenv==20.14.1
+virtualenv==20.16.2
     # via
     #   -r requirements/ci.txt
     #   tox
@@ -370,7 +377,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/doc.txt
     #   astroid
-zipp==3.8.0
+zipp==3.8.1
     # via
     #   -r requirements/doc.txt
     #   importlib-metadata

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -4,12 +4,12 @@
 #
 #    make upgrade
 #
-astroid==2.11.6
+astroid==2.11.7
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
@@ -28,7 +28,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==6.4.1
+coverage[toml]==6.4.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -49,7 +49,7 @@ execnet==1.9.0
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.47.3
+hypothesis==6.53.0
     # via -r requirements/test.txt
 isort==5.10.1
     # via
@@ -105,7 +105,7 @@ py==1.11.0
     #   pytest-forked
 pycodestyle==2.8.0
     # via -r requirements/test.txt
-pylint==2.14.3
+pylint==2.14.5
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -180,7 +180,7 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -197,11 +197,11 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   coverage
     #   pylint
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -6,23 +6,23 @@
 #
 alabaster==0.7.12
     # via sphinx
-astroid==2.11.6
+astroid==2.11.7
     # via
     #   -r requirements/test.txt
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
     #   pytest
 babel==2.10.3
     # via sphinx
-bleach==5.0.0
+bleach==5.0.1
     # via readme-renderer
 certifi==2022.6.15
     # via requests
-charset-normalizer==2.0.12
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -38,7 +38,7 @@ code-annotations==1.3.0
     # via
     #   -r requirements/test.txt
     #   edx-lint
-coverage[toml]==6.4.1
+coverage[toml]==6.4.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -48,7 +48,7 @@ dill==0.3.5.1
     # via
     #   -r requirements/test.txt
     #   pylint
-docutils==0.18.1
+docutils==0.19
     # via
     #   readme-renderer
     #   sphinx
@@ -65,13 +65,13 @@ execnet==1.9.0
     #   -r requirements/test.txt
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.47.3
+hypothesis==6.53.0
     # via -r requirements/test.txt
 idna==3.3
     # via requests
-imagesize==1.3.0
+imagesize==1.4.1
     # via sphinx
-importlib-metadata==4.11.4
+importlib-metadata==4.12.0
     # via sphinx
 isort==5.10.1
     # via
@@ -133,7 +133,7 @@ pygments==2.12.0
     # via
     #   readme-renderer
     #   sphinx
-pylint==2.14.3
+pylint==2.14.5
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -200,7 +200,7 @@ pyyaml==6.0
     #   code-annotations
 readme-renderer==35.0
     # via -r requirements/doc.in
-requests==2.28.0
+requests==2.28.1
     # via sphinx
 six==1.16.0
     # via
@@ -215,7 +215,7 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/test.txt
     #   hypothesis
-sphinx==5.0.2
+sphinx==5.1.1
     # via
     #   -r requirements/doc.in
     #   edx-sphinx-theme
@@ -231,7 +231,7 @@ sphinxcontrib-qthelp==1.0.3
     # via sphinx
 sphinxcontrib-serializinghtml==1.1.5
     # via sphinx
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/test.txt
     #   code-annotations
@@ -248,16 +248,16 @@ tomli==2.0.1
     #   -r requirements/test.txt
     #   coverage
     #   pylint
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   -r requirements/test.txt
     #   astroid
     #   pylint
-urllib3==1.26.9
+urllib3==1.26.11
     # via requests
 wcwidth==0.2.5
     # via
@@ -269,7 +269,7 @@ wrapt==1.14.1
     # via
     #   -r requirements/test.txt
     #   astroid
-zipp==3.8.0
+zipp==3.8.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -4,14 +4,22 @@
 #
 #    make upgrade
 #
+build==0.8.0
+    # via pip-tools
 click==8.1.3
     # via pip-tools
+packaging==21.3
+    # via build
 pep517==0.12.0
-    # via pip-tools
-pip-tools==6.6.2
+    # via build
+pip-tools==6.8.0
     # via -r requirements/pip-tools.in
+pyparsing==3.0.9
+    # via packaging
 tomli==2.0.1
-    # via pep517
+    # via
+    #   build
+    #   pep517
 wheel==0.37.1
     # via pip-tools
 

--- a/requirements/pip.in
+++ b/requirements/pip.in
@@ -1,4 +1,5 @@
 # Core dependencies for installing other packages
+-c constraints.txt
 
 pip
 setuptools

--- a/requirements/pip.txt
+++ b/requirements/pip.txt
@@ -8,7 +8,9 @@ wheel==0.37.1
     # via -r requirements/pip.in
 
 # The following packages are considered to be unsafe in a requirements file:
-pip==22.1.2
+pip==22.2.1
     # via -r requirements/pip.in
-setuptools==62.6.0
-    # via -r requirements/pip.in
+setuptools==59.8.0
+    # via
+    #   -c https://raw.githubusercontent.com/edx/edx-lint/master/edx_lint/files/common_constraints.txt
+    #   -r requirements/pip.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,11 +4,11 @@
 #
 #    make upgrade
 #
-astroid==2.11.6
+astroid==2.11.7
     # via
     #   pylint
     #   pylint-celery
-attrs==21.4.0
+attrs==22.1.0
     # via
     #   hypothesis
     #   pytest
@@ -21,7 +21,7 @@ click-log==0.4.0
     # via edx-lint
 code-annotations==1.3.0
     # via edx-lint
-coverage[toml]==6.4.1
+coverage[toml]==6.4.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -37,7 +37,7 @@ execnet==1.9.0
     # via
     #   pytest-cache
     #   pytest-xdist
-hypothesis==6.47.3
+hypothesis==6.53.0
     # via -r requirements/test.in
 isort==5.10.1
     # via pylint
@@ -73,7 +73,7 @@ py==1.11.0
     #   pytest-forked
 pycodestyle==2.8.0
     # via -r requirements/test.in
-pylint==2.14.3
+pylint==2.14.5
     # via
     #   edx-lint
     #   pylint-celery
@@ -126,7 +126,7 @@ six==1.16.0
     #   pytest-xdist
 sortedcontainers==2.4.0
     # via hypothesis
-stevedore==3.5.0
+stevedore==4.0.0
     # via
     #   -r requirements/base.txt
     #   code-annotations
@@ -138,9 +138,9 @@ tomli==2.0.1
     # via
     #   coverage
     #   pylint
-tomlkit==0.11.0
+tomlkit==0.11.1
     # via pylint
-typing-extensions==4.2.0
+typing-extensions==4.3.0
     # via
     #   astroid
     #   pylint


### PR DESCRIPTION
Updated the upgrade target script to check the compatibility of upgraded pip and pip-tools versions.
For reference, look at this https://github.com/openedx/edx-repo-health/pull/271 for new check added in edx-repo-health.