### PR TITLE
feat: Add type hints

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+# 2.5.0
+
+* Added python type hints
+
 # 2.4.0
 
 * Added Support for Django 4.2

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,5 @@
+[mypy]
+follow_imports = normal
+ignore_missing_imports = True
+allow_untyped_globals = False
+files = opaque_keys

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,4 +1,5 @@
 [mypy]
+python_version = 3.8
 follow_imports = normal
 ignore_missing_imports = True
 allow_untyped_globals = False

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from functools import total_ordering
 from stevedore.enabled import EnabledExtensionManager
 from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
-__version__ = '2.4.0'
+__version__ = '2.5.0'
 
 
 class InvalidKeyError(Exception):

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from functools import total_ordering
-from typing import Self
 
 from stevedore.enabled import EnabledExtensionManager
+from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
 __version__ = '2.4.0'
 

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -3,7 +3,6 @@ Useful django models for implementing XBlock infrastructure in django.
 If Django is unavailable, none of the classes below will work as intended.
 """
 from __future__ import annotations
-# pylint: disable=abstract-method
 import logging
 import warnings
 
@@ -43,7 +42,7 @@ class _Creator:
         obj.__dict__[self.field.name] = self.field.to_python(value)
 
 
-# pylint: disable=missing-docstring,unused-argument
+# pylint: disable=unused-argument
 class CreatorMixin:
     """
     Mixin class to provide SubfieldBase functionality to django fields.
@@ -79,7 +78,6 @@ def _strip_value(value, lookup='exact'):
     return stripped_value
 
 
-# pylint: disable=logging-format-interpolation
 class OpaqueKeyField(CreatorMixin, CharField):
     """
     A django field for storing OpaqueKeys.
@@ -102,7 +100,7 @@ class OpaqueKeyField(CreatorMixin, CharField):
 
         super().__init__(*args, **kwargs)
 
-    def to_python(self, value):
+    def to_python(self, value):  # pylint: disable=missing-function-docstring
         if value is self.Empty or value is None:
             return None
 
@@ -130,13 +128,12 @@ class OpaqueKeyField(CreatorMixin, CharField):
             return self.KEY_CLASS.from_string(value)
         return value
 
-    def get_prep_value(self, value):
+    def get_prep_value(self, value):  # pylint: disable=missing-function-docstring
         if value is self.Empty or value is None:
             return ''  # CharFields should use '' as their empty value, rather than None
 
         if isinstance(value, str):
             value = self.KEY_CLASS.from_string(value)
-        # pylint: disable=isinstance-second-argument-not-valid-type
         assert isinstance(value, self.KEY_CLASS), f"{value} is not an instance of {self.KEY_CLASS}"
         serialized_key = str(_strip_value(value))
         if serialized_key.endswith('\n'):
@@ -180,7 +177,6 @@ class OpaqueKeyFieldEmptyLookupIsNull(IsNull):
 
 
 try:
-    #  pylint: disable=no-member
     OpaqueKeyField.register_lookup(OpaqueKeyFieldEmptyLookupIsNull)
 except AttributeError:
     #  Django was not imported

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -2,6 +2,7 @@
 Useful django models for implementing XBlock infrastructure in django.
 If Django is unavailable, none of the classes below will work as intended.
 """
+from __future__ import annotations
 # pylint: disable=abstract-method
 import logging
 import warnings

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -16,6 +16,7 @@ except ImportError:  # pragma: no cover
     CharField = object
     IsNull = object
 
+from opaque_keys import OpaqueKey
 from opaque_keys.edx.keys import BlockTypeKey, CourseKey, LearningContextKey, UsageKey
 
 
@@ -92,7 +93,7 @@ class OpaqueKeyField(CreatorMixin, CharField):
     description = "An OpaqueKey object, saved to the DB in the form of a string."
 
     Empty = object()
-    KEY_CLASS = None
+    KEY_CLASS: type[OpaqueKey]
 
     def __init__(self, *args, **kwargs):
         if self.KEY_CLASS is None:

--- a/opaque_keys/edx/django/tests/models.py
+++ b/opaque_keys/edx/django/tests/models.py
@@ -34,7 +34,6 @@ class Container:
         return self.text == obj.text
 
 
-#  pylint: disable=missing-docstring
 class ExampleField(CreatorMixin, CharField):
     """A simple Django Field to assist in testing the CreatorMixin class."""
 

--- a/opaque_keys/edx/django/tests/test_models.py
+++ b/opaque_keys/edx/django/tests/test_models.py
@@ -32,7 +32,7 @@ class TestCreatorMixin(TestCase):
 
     def test_char_field_is_converted_to_container(self):
         expected = Container('key-1').transform()
-        self.assertEqual(expected, self.model.key.transform())
+        self.assertEqual(expected, self.model.key.transform())  # pylint: disable=no-member
 
     def test_load_model_from_db(self):
         fetched_model = ExampleModel.objects.get(key='key-1')
@@ -47,8 +47,8 @@ class EmptyKeyClassField(OpaqueKeyField):
 class TestOpaqueKeyField(TestCase):
     """Tests the implementation of OpaqueKeyField methods."""
     def test_null_key_class_raises_value_error(self):
-        with self.assertRaises(ValueError):
-            EmptyKeyClassField()
+        with self.assertRaises(AttributeError):
+            EmptyKeyClassField()  # AttributeError: 'EmptyKeyClassField' object has no attribute 'KEY_CLASS'
 
     def test_to_python_trailing_newline_stripped(self):
         field = ComplexModel()._meta.get_field('course_key')

--- a/opaque_keys/edx/django/tests/test_models.py
+++ b/opaque_keys/edx/django/tests/test_models.py
@@ -23,7 +23,6 @@ def enable_db_access_for_all_tests(db):
     """Enable DB access for all tests."""
 
 
-#  pylint: disable=no-member
 class TestCreatorMixin(TestCase):
     """Tests of the CreatorMixin class."""
     def setUp(self):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -11,7 +11,7 @@ from typing_extensions import Self  # For python 3.11 plus, can just use "from t
 from opaque_keys import OpaqueKey
 
 
-class LearningContextKey(OpaqueKey):
+class LearningContextKey(OpaqueKey):  # pylint: disable=abstract-method
     """
     An :class:`opaque_keys.OpaqueKey` identifying a course, a library, a
     program, a website, or some other collection of content where learning
@@ -307,7 +307,7 @@ class i4xEncoder(json.JSONEncoder):  # pylint: disable=invalid-name
     If provided as the cls to json.dumps, will serialize and Locations as i4x strings and other
     keys using the unicode strings.
     """
-    def default(self, o):  # pylint: disable=arguments-differ, method-hidden
+    def default(self, o):
         if isinstance(o, OpaqueKey):
             return str(o)
         super().default(o)

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -1,9 +1,10 @@
 """
-;
 OpaqueKey abstract classes for edx-platform object types (courses, definitions, usages, and assets).
 """
+from __future__ import annotations
 import json
 from abc import abstractmethod
+from typing import Self
 import warnings
 
 from opaque_keys import OpaqueKey
@@ -30,13 +31,6 @@ class LearningContextKey(OpaqueKey):
     # just isinstance(key, CourseKey)
     is_course = False
 
-    def make_definition_usage(self, definition_key, usage_id=None):
-        """
-        Return a usage key, given the given the specified definition key and
-        usage_id.
-        """
-        raise NotImplementedError()
-
 
 class CourseKey(LearningContextKey):
     """
@@ -47,7 +41,7 @@ class CourseKey(LearningContextKey):
 
     @property
     @abstractmethod
-    def org(self):  # pragma: no cover
+    def org(self) -> str | None:  # pragma: no cover
         """
         The organization that this course belongs to.
         """
@@ -55,7 +49,7 @@ class CourseKey(LearningContextKey):
 
     @property
     @abstractmethod
-    def course(self):  # pragma: no cover
+    def course(self) -> str | None:  # pragma: no cover
         """
         The name for this course.
 
@@ -65,7 +59,7 @@ class CourseKey(LearningContextKey):
 
     @property
     @abstractmethod
-    def run(self):  # pragma: no cover
+    def run(self) -> str | None:  # pragma: no cover
         """
         The run for this course.
 
@@ -74,7 +68,7 @@ class CourseKey(LearningContextKey):
         raise NotImplementedError()
 
     @abstractmethod
-    def make_usage_key(self, block_type, block_id):  # pragma: no cover
+    def make_usage_key(self, block_type: str, block_id: str) -> UsageKey:  # pragma: no cover
         """
         Return a usage key, given the given the specified block_type and block_id.
 
@@ -84,7 +78,7 @@ class CourseKey(LearningContextKey):
         raise NotImplementedError()
 
     @abstractmethod
-    def make_asset_key(self, asset_type, path):  # pragma: no cover
+    def make_asset_key(self, asset_type: str, path: str) -> AssetKey:  # pragma: no cover
         """
         Return an asset key, given the given the specified path.
 
@@ -103,7 +97,7 @@ class DefinitionKey(OpaqueKey):
 
     @property
     @abstractmethod
-    def block_type(self):  # pragma: no cover
+    def block_type(self) -> str:  # pragma: no cover
         """
         The XBlock type of this definition.
         """
@@ -119,14 +113,14 @@ class CourseObjectMixin:
 
     @property
     @abstractmethod
-    def course_key(self):  # pragma: no cover
+    def course_key(self) -> CourseKey:  # pragma: no cover
         """
         Return the :class:`CourseKey` for the course containing this usage.
         """
         raise NotImplementedError()
 
     @abstractmethod
-    def map_into_course(self, course_key):  # pragma: no cover
+    def map_into_course(self, course_key: CourseKey) -> Self:  # pragma: no cover
         """
         Return a new :class:`UsageKey` or :class:`AssetKey` representing this usage inside the
         course identified by the supplied :class:`CourseKey`. It returns the same type as
@@ -150,7 +144,7 @@ class AssetKey(CourseObjectMixin, OpaqueKey):
 
     @property
     @abstractmethod
-    def asset_type(self):  # pragma: no cover
+    def asset_type(self) -> str:  # pragma: no cover
         """
         Return what type of asset this is.
         """
@@ -158,7 +152,7 @@ class AssetKey(CourseObjectMixin, OpaqueKey):
 
     @property
     @abstractmethod
-    def path(self):  # pragma: no cover
+    def path(self) -> str:  # pragma: no cover
         """
         Return the path for this asset.
         """
@@ -174,7 +168,7 @@ class UsageKey(CourseObjectMixin, OpaqueKey):
 
     @property
     @abstractmethod
-    def definition_key(self):  # pragma: no cover
+    def definition_key(self) -> DefinitionKey:  # pragma: no cover
         """
         Return the :class:`DefinitionKey` for the XBlock containing this usage.
         """
@@ -182,7 +176,7 @@ class UsageKey(CourseObjectMixin, OpaqueKey):
 
     @property
     @abstractmethod
-    def block_type(self):
+    def block_type(self) -> str:
         """
         The XBlock type of this usage.
         """
@@ -190,14 +184,14 @@ class UsageKey(CourseObjectMixin, OpaqueKey):
 
     @property
     @abstractmethod
-    def block_id(self):
+    def block_id(self) -> str:
         """
         The name of this usage.
         """
         raise NotImplementedError()
 
     @property
-    def context_key(self):
+    def context_key(self) -> LearningContextKey:
         """
         Get the learning context key (LearningContextKey) for this XBlock usage.
         """
@@ -224,7 +218,7 @@ class UsageKeyV2(UsageKey):
 
     @property
     @abstractmethod
-    def context_key(self):
+    def context_key(self) -> LearningContextKey:
         """
         Get the learning context key (LearningContextKey) for this XBlock usage.
         May be a course key, library key, or some other LearningContextKey type.
@@ -232,7 +226,7 @@ class UsageKeyV2(UsageKey):
         raise NotImplementedError()
 
     @property
-    def definition_key(self):
+    def definition_key(self) -> DefinitionKey:
         """
         Returns the definition key for this usage. For the newer V2 key types,
         this cannot be done with the key alone, so it's necessary to ask the
@@ -245,11 +239,11 @@ class UsageKeyV2(UsageKey):
         )
 
     @property
-    def course_key(self):
+    def course_key(self) -> CourseKey:
         warnings.warn("Use .context_key instead of .course_key", DeprecationWarning, stacklevel=2)
-        return self.context_key
+        return self.context_key  # type: ignore
 
-    def map_into_course(self, course_key):
+    def map_into_course(self, course_key: CourseKey) -> Self:
         """
         Implement map_into_course for API compatibility. Shouldn't be used in
         new code.
@@ -329,7 +323,7 @@ class BlockTypeKey(OpaqueKey):
 
     @property
     @abstractmethod
-    def block_family(self):
+    def block_family(self) -> str:
         """
         Return the block-family identifier (the entry-point used to load that block
         family).
@@ -338,7 +332,7 @@ class BlockTypeKey(OpaqueKey):
 
     @property
     @abstractmethod
-    def block_type(self):
+    def block_type(self) -> str:
         """
         Return the block_type of this block (the key in the entry-point to load the block
         with).

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -4,8 +4,9 @@ OpaqueKey abstract classes for edx-platform object types (courses, definitions, 
 from __future__ import annotations
 import json
 from abc import abstractmethod
-from typing import Self
 import warnings
+
+from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
 from opaque_keys import OpaqueKey
 

--- a/opaque_keys/edx/locations.py
+++ b/opaque_keys/edx/locations.py
@@ -1,7 +1,7 @@
 """
 Deprecated OpaqueKey implementations used by XML and Mongo modulestores
 """
-
+from __future__ import annotations
 import re
 import warnings
 
@@ -67,7 +67,7 @@ class SlashSeparatedCourseKey(CourseLocator):
 class LocationBase:
     """Deprecated. Base class for :class:`Location` and :class:`AssetLocation`"""
 
-    DEPRECATED_TAG = None  # Subclasses should define what DEPRECATED_TAG is
+    DEPRECATED_TAG: str | None = None  # Subclasses should define what DEPRECATED_TAG is
 
     @classmethod
     def _deprecation_warning(cls):

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -5,13 +5,14 @@ from __future__ import annotations
 import inspect
 import logging
 import re
-from typing import Any, Literal, Self
+from typing import Any
 import warnings
 from uuid import UUID
 
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
 from bson.son import SON
+from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
 from opaque_keys import OpaqueKey, InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey, DefinitionKey, LearningContextKey, UsageKey, UsageKeyV2

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -127,7 +127,7 @@ class BlockLocatorBase(Locator):
     URL_RE = re.compile('^' + URL_RE_SOURCE + r'\Z', re.VERBOSE | re.UNICODE)
 
     @classmethod
-    def parse_url(cls, string: str) -> dict[str, str]:  # pylint: disable=redefined-outer-name
+    def parse_url(cls, string: str) -> dict[str, str]:
         """
         If it can be parsed as a version_guid with no preceding org + offering, returns a dict
         with key 'version_guid' and the value,
@@ -144,7 +144,7 @@ class BlockLocatorBase(Locator):
         return match.groupdict()  # type: ignore
 
 
-class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-method
+class CourseLocator(BlockLocatorBase, CourseKey):
     """
     Examples of valid CourseLocator specifications:
      CourseLocator(version_guid=ObjectId('519665f6223ebd6980884f2b'))
@@ -160,9 +160,6 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
     the persistence layer may raise exceptions if the given version != the current such version
     of the course.
     """
-
-    # pylint: disable=no-member
-
     CANONICAL_NAMESPACE = 'course-v1'
     KEY_FIELDS = ('org', 'course', 'run', 'branch', 'version_guid')
     org: str | None
@@ -244,7 +241,7 @@ class CourseLocator(BlockLocatorBase, CourseKey):   # pylint: disable=abstract-m
             raise InvalidKeyError(self.__class__, "Either version_guid or org, course, and run should be set")
 
     @classmethod
-    def _check_location_part(cls, val, regexp):  # pylint: disable=missing-docstring
+    def _check_location_part(cls, val, regexp):  # pylint: disable=missing-function-docstring
         if val is None:
             return
         if not isinstance(val, str):
@@ -437,6 +434,7 @@ class LibraryLocator(BlockLocatorBase, CourseKey):
     RUN = 'library'  # For backwards compatibility, LibraryLocators have a read-only 'run' property equal to this
     KEY_FIELDS = ('org', 'library', 'branch', 'version_guid')
     library: str
+    branch: str
     version_guid: ObjectId
     __slots__ = KEY_FIELDS
     CHECKED_INIT = False
@@ -494,7 +492,7 @@ class LibraryLocator(BlockLocatorBase, CourseKey):
             **kwargs
         )
 
-        if self.version_guid is None and (self.org is None or self.library is None):  # pylint: disable=no-member
+        if self.version_guid is None and (self.org is None or self.library is None):
             raise InvalidKeyError(self.__class__, "Either version_guid or org and library should be set")
 
     @property
@@ -511,7 +509,7 @@ class LibraryLocator(BlockLocatorBase, CourseKey):
         Deprecated. Return a 'course' for compatibility with CourseLocator.
         """
         warnings.warn("Accessing 'course' on a LibraryLocator is deprecated.", DeprecationWarning, stacklevel=2)
-        return self.library  # pylint: disable=no-member
+        return self.library
 
     @property
     def version(self):
@@ -524,7 +522,7 @@ class LibraryLocator(BlockLocatorBase, CourseKey):
             DeprecationWarning,
             stacklevel=2
         )
-        return self.version_guid  # pylint: disable=no-member
+        return self.version_guid
 
     @classmethod
     def _from_string(cls, serialized):
@@ -601,12 +599,12 @@ class LibraryLocator(BlockLocatorBase, CourseKey):
         Return a string representing this location.
         """
         parts = []
-        if self.library:  # pylint: disable=no-member
-            parts.extend([self.org, self.library])  # pylint: disable=no-member
-            if self.branch:  # pylint: disable=no-member
-                parts.append(f"{self.BRANCH_PREFIX}@{self.branch}")  # pylint: disable=no-member
-        if self.version_guid:  # pylint: disable=no-member
-            parts.append(f"{self.VERSION_PREFIX}@{self.version_guid}")  # pylint: disable=no-member
+        if self.library:
+            parts.extend([self.org, self.library])
+            if self.branch:
+                parts.append(f"{self.BRANCH_PREFIX}@{self.branch}")
+        if self.version_guid:
+            parts.append(f"{self.VERSION_PREFIX}@{self.version_guid}")
         return "+".join(parts)
 
     def _to_deprecated_string(self):
@@ -1098,7 +1096,6 @@ class LibraryUsageLocator(BlockUsageLocator):
             ) from error
 
         # We skip the BlockUsageLocator init and go to its superclass:
-        # pylint: disable=bad-super-call
         super(BlockUsageLocator, self).__init__(library_key=library_key, block_type=block_type, block_id=block_id,
                                                 **kwargs)
 
@@ -1320,7 +1317,6 @@ class AssetLocator(BlockUsageLocator, AssetKey):    # pylint: disable=abstract-m
 
         /c4x/org/course/category/name
         """
-        # pylint: disable=missing-format-attribute
         url = (
             f"/{self.DEPRECATED_TAG}/{self.course_key.org}/{self.course_key.course}"
             f"/{self.block_type}/{self.block_id}"
@@ -1416,8 +1412,6 @@ class BundleDefinitionLocator(CheckFieldMixin, DefinitionKey):
     __slots__ = KEY_FIELDS
     CHECKED_INIT = False
     OLX_PATH_REGEXP = re.compile(r'^[\w\-./]+$', flags=re.UNICODE)
-
-    # pylint: disable=no-member
 
     def __init__(
         self,
@@ -1548,8 +1542,6 @@ class LibraryLocatorV2(CheckFieldMixin, LearningContextKey):
     # Allow library slugs to contain unicode characters
     SLUG_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)
 
-    # pylint: disable=no-member
-
     def __init__(self, org, slug):
         """
         Construct a LibraryLocatorV2
@@ -1604,8 +1596,6 @@ class LibraryUsageLocatorV2(CheckFieldMixin, UsageKeyV2):
 
     # Allow usage IDs to contian unicode characters
     USAGE_ID_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)
-
-    # pylint: disable=no-member
 
     def __init__(self, lib_key: LibraryLocatorV2, block_type: str, usage_id: str):
         """

--- a/opaque_keys/edx/tests/__init__.py
+++ b/opaque_keys/edx/tests/__init__.py
@@ -20,7 +20,6 @@ class TestDeprecated(TestCase):
         warnings.simplefilter('always', DeprecationWarning)
 
         # Manually exit the catch_warnings context manager when the test is done
-        # pylint: disable-next=unnecessary-dunder-call
         self.addCleanup(self.cws.__exit__)
 
     @contextmanager

--- a/opaque_keys/edx/tests/test_course_locators.py
+++ b/opaque_keys/edx/tests/test_course_locators.py
@@ -79,7 +79,7 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
             CourseLocator(version_guid=None)
 
     def test_course_constructor_version_guid(self):
-        # pylint: disable=no-member,protected-access
+        # pylint: disable=protected-access
 
         # generate a random location
         test_id_1 = ObjectId()
@@ -234,7 +234,7 @@ class TestCourseKeys(LocatorBaseTest, TestDeprecated):
             branch=test_branch,
         )
 
-        # pylint: disable=no-member,protected-access
+        # pylint: disable=protected-access
         self.assertEqual(testobj.branch, test_branch)
         self.assertEqual(testobj._to_string(), expected_urn)
 

--- a/opaque_keys/edx/tests/test_library_locators.py
+++ b/opaque_keys/edx/tests/test_library_locators.py
@@ -1,8 +1,7 @@
 """
 Tests of LibraryLocators
 """
-
-import itertools  # pylint: disable=wrong-import-order
+import itertools
 from unittest import TestCase
 
 import ddt
@@ -48,12 +47,12 @@ class TestLibraryLocators(LocatorBaseTest, TestDeprecated):
         code = 'test-problem-bank'
         lib_key = LibraryLocator(org=org, library=code)
         self.assertEqual(lib_key.org, org)
-        self.assertEqual(lib_key.library, code)  # pylint: disable=no-member
+        self.assertEqual(lib_key.library, code)
         with self.assertDeprecationWarning():
             self.assertEqual(lib_key.course, code)
         with self.assertDeprecationWarning():
             self.assertEqual(lib_key.run, 'library')
-        self.assertEqual(lib_key.branch, None)  # pylint: disable=no-member
+        self.assertEqual(lib_key.branch, None)
 
     def test_constructor_using_course(self):
         org = 'TestX'
@@ -62,7 +61,7 @@ class TestLibraryLocators(LocatorBaseTest, TestDeprecated):
         with self.assertDeprecationWarning():
             lib_key2 = LibraryLocator(org=org, course=code)
         self.assertEqual(lib_key, lib_key2)
-        self.assertEqual(lib_key2.library, code)  # pylint: disable=no-member
+        self.assertEqual(lib_key2.library, code)
 
     def test_version_property_deprecated(self):
         lib_key = CourseKey.from_string('library-v1:TestX+lib1+version@519665f6223ebd6980884f2b')
@@ -120,11 +119,11 @@ class TestLibraryLocators(LocatorBaseTest, TestDeprecated):
         branch = 'future-purposes-perhaps'
         lib_key = LibraryLocator(org=org, library=code, branch=branch)
         self.assertEqual(lib_key.org, org)
-        self.assertEqual(lib_key.library, code)  # pylint: disable=no-member
-        self.assertEqual(lib_key.branch, branch)  # pylint: disable=no-member
+        self.assertEqual(lib_key.library, code)
+        self.assertEqual(lib_key.branch, branch)
         lib_key2 = CourseKey.from_string(str(lib_key))
         self.assertEqual(lib_key, lib_key2)
-        self.assertEqual(lib_key.branch, branch)  # pylint: disable=no-member
+        self.assertEqual(lib_key.branch, branch)
 
     def test_for_branch(self):
         lib_key = LibraryLocator(org='TestX', library='test', branch='initial')
@@ -139,7 +138,7 @@ class TestLibraryLocators(LocatorBaseTest, TestDeprecated):
     def test_version_only_lib_key(self):
         version_only_lib_key = LibraryLocator(version_guid=ObjectId('519665f6223ebd6980884f2b'))
         self.assertEqual(version_only_lib_key.org, None)
-        self.assertEqual(version_only_lib_key.library, None)  # pylint: disable=no-member
+        self.assertEqual(version_only_lib_key.library, None)
         with self.assertRaises(InvalidKeyError):
             version_only_lib_key.for_branch("test")
 
@@ -182,10 +181,10 @@ class TestLibraryLocators(LocatorBaseTest, TestDeprecated):
         version_id_obj = ObjectId(version_id)
 
         lib_key = LibraryLocator(version_guid=version_id)
-        self.assertEqual(lib_key.version_guid, version_id_obj)  # pylint: disable=no-member
+        self.assertEqual(lib_key.version_guid, version_id_obj)
         self.assertEqual(lib_key.org, None)
-        self.assertEqual(lib_key.library, None)  # pylint: disable=no-member
-        self.assertEqual(str(lib_key.version_guid), version_id_str)  # pylint: disable=no-member
+        self.assertEqual(lib_key.library, None)
+        self.assertEqual(str(lib_key.version_guid), version_id_str)
         # Allow access to _to_string
         # pylint: disable=protected-access
         expected_str = '@'.join((lib_key.VERSION_PREFIX, version_id_str))

--- a/opaque_keys/edx/tests/test_library_usage_locators.py
+++ b/opaque_keys/edx/tests/test_library_usage_locators.py
@@ -1,8 +1,7 @@
 """
 Tests of LibraryUsageLocator
 """
-
-import itertools  # pylint: disable=wrong-import-order
+import itertools
 from unittest import TestCase
 
 import ddt

--- a/opaque_keys/edx/tests/test_properties.py
+++ b/opaque_keys/edx/tests/test_properties.py
@@ -22,7 +22,6 @@ LOGGER = logging.getLogger(__name__)
 
 # composite strategies confuse pylint (because they silently provide the `draw`
 # argument), so we stop it from complaining about them.
-# pylint: disable=no-value-for-parameter
 
 
 def insert(string, index, character):

--- a/opaque_keys/tests/strategies.py
+++ b/opaque_keys/tests/strategies.py
@@ -162,7 +162,7 @@ def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstri
 
 @fields_for_key.register(AsideUsageKeyV1)
 @cacheable
-def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docstring
     if field == 'deprecated':
         return strategies.just(False)
     if field == 'usage_key':
@@ -184,7 +184,7 @@ def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstri
 
 @fields_for_key.register(AsideUsageKeyV2)
 @cacheable
-def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docstring
     if field == 'deprecated':
         return strategies.just(False)
     if field == 'usage_key':
@@ -194,7 +194,7 @@ def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(LibraryLocator)
 @cacheable
-def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstring
     if field == 'version_guid':
         return version_guids()
     if field in ('org', 'library', 'branch'):
@@ -206,7 +206,7 @@ def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstrin
 
 @fields_for_key.register(LibraryLocatorV2)
 @cacheable
-def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docstring
     if field == 'org':
         return ascii_identifier()
     if field == 'slug':
@@ -216,7 +216,7 @@ def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(DefinitionLocator)
 @cacheable
-def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docstring
     if field == 'definition_id':
         return version_guids()
     if field == 'block_type':
@@ -226,7 +226,7 @@ def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(BundleDefinitionLocator)
 @cacheable
-def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docstring
     if field == 'bundle_uuid':
         return strategies.uuids()
     if field == 'block_type':
@@ -240,7 +240,7 @@ def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(LibraryUsageLocatorV2)
 @cacheable
-def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docstring, function-redefined
+def _fields_for_library_usage_locator_v2(cls, field):  # pylint: disable=missing-docstring
     if field == 'lib_key':
         return instances_of_key(LibraryLocatorV2)
     if field == 'block_type':
@@ -277,7 +277,7 @@ def instances_of_key(cls, **kwargs):
 
 @instances_of_key.register(BlockTypeKeyV1)
 @cacheable
-def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
+def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docstring
 
     return strategies.builds(
         cls,
@@ -293,7 +293,7 @@ def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docs
 
 @instances_of_key.register(CourseLocator)
 @cacheable
-def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
+def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docstring
 
     return strategies.builds(
         cls,
@@ -315,7 +315,7 @@ def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docs
 
 @instances_of_key.register(BlockUsageLocator)
 @cacheable
-def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
+def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstring
 
     def locator_for_course(course_key):
         """
@@ -343,7 +343,7 @@ def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstri
 
 @instances_of_key.register(LibraryUsageLocator)
 @cacheable
-def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
+def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docstring
 
     return strategies.builds(
         cls,
@@ -355,7 +355,7 @@ def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docst
 
 @instances_of_key.register(DeprecatedLocation)
 @cacheable
-def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docstring, function-redefined
+def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docstring
 
     return strategies.builds(
         cls,

--- a/opaque_keys/tests/strategies.py
+++ b/opaque_keys/tests/strategies.py
@@ -112,7 +112,7 @@ def classdispatch(func):
     """
     dispatcher = singledispatch(func)
 
-    def wrapper(*args, **kw):  # pylint: disable=missing-docstring
+    def wrapper(*args, **kw):
         return dispatcher.dispatch(args[0])(*args, **kw)
 
     wrapper.register = dispatcher.register
@@ -150,11 +150,11 @@ def _aside_v1_exclusions(draw, strategy):
 
 @fields_for_key.register(AsideDefinitionKeyV1)
 @cacheable
-def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'deprecated':
         return strategies.just(False)
     if field == 'definition_key':
-        return _aside_v1_exclusions(  # pylint: disable=no-value-for-parameter
+        return _aside_v1_exclusions(
             keys_of_type(DefinitionKey, blacklist=AsideDefinitionKey)
         )
     return fields_for_key(super(AsideDefinitionKeyV1, cls).__class__, field)
@@ -162,11 +162,11 @@ def _fields_for_aside_def_key_v1(cls, field):  # pylint: disable=missing-docstri
 
 @fields_for_key.register(AsideUsageKeyV1)
 @cacheable
-def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'deprecated':
         return strategies.just(False)
     if field == 'usage_key':
-        return _aside_v1_exclusions(  # pylint: disable=no-value-for-parameter
+        return _aside_v1_exclusions(
             keys_of_type(UsageKey, blacklist=AsideUsageKey)
         )
     return fields_for_key(super(AsideUsageKeyV1, cls).__class__, field)
@@ -174,7 +174,7 @@ def _fields_for_aside_usage_key_v1(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(AsideDefinitionKeyV2)
 @cacheable
-def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'deprecated':
         return strategies.just(False)
     if field == 'definition_key':
@@ -184,7 +184,7 @@ def _fields_for_aside_def_key_v2(cls, field):  # pylint: disable=missing-docstri
 
 @fields_for_key.register(AsideUsageKeyV2)
 @cacheable
-def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'deprecated':
         return strategies.just(False)
     if field == 'usage_key':
@@ -194,7 +194,7 @@ def _fields_for_aside_usage_key_v2(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(LibraryLocator)
 @cacheable
-def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_library_locator(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'version_guid':
         return version_guids()
     if field in ('org', 'library', 'branch'):
@@ -206,7 +206,7 @@ def _fields_for_library_locator(cls, field):  # pylint: disable=missing-docstrin
 
 @fields_for_key.register(LibraryLocatorV2)
 @cacheable
-def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'org':
         return ascii_identifier()
     if field == 'slug':
@@ -216,7 +216,7 @@ def _fields_for_library_locator_v2(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(DefinitionLocator)
 @cacheable
-def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'definition_id':
         return version_guids()
     if field == 'block_type':
@@ -226,7 +226,7 @@ def _fields_for_definition_locator(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(BundleDefinitionLocator)
 @cacheable
-def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'bundle_uuid':
         return strategies.uuids()
     if field == 'block_type':
@@ -240,7 +240,7 @@ def _fields_for_bundle_def_locator(cls, field):  # pylint: disable=missing-docst
 
 @fields_for_key.register(LibraryUsageLocatorV2)
 @cacheable
-def _fields_for_library_usage_locator_v2(cls, field):  # pylint: disable=missing-docstring
+def _fields_for_library_usage_locator_v2(cls, field):  # pylint: disable=missing-function-docstring
     if field == 'lib_key':
         return instances_of_key(LibraryLocatorV2)
     if field == 'block_type':
@@ -277,8 +277,7 @@ def instances_of_key(cls, **kwargs):
 
 @instances_of_key.register(BlockTypeKeyV1)
 @cacheable
-def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docstring
-
+def _instances_of_block_type_key(cls, **kwargs):
     return strategies.builds(
         cls,
         block_family=kwargs.get('block_family', (
@@ -293,7 +292,7 @@ def _instances_of_block_type_key(cls, **kwargs):  # pylint: disable=missing-docs
 
 @instances_of_key.register(CourseLocator)
 @cacheable
-def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docstring
+def _instances_of_course_locator(cls, **kwargs):
 
     return strategies.builds(
         cls,
@@ -315,7 +314,7 @@ def _instances_of_course_locator(cls, **kwargs):  # pylint: disable=missing-docs
 
 @instances_of_key.register(BlockUsageLocator)
 @cacheable
-def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstring
+def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-function-docstring
 
     def locator_for_course(course_key):
         """
@@ -343,7 +342,7 @@ def _instances_of_block_usage(cls, **kwargs):  # pylint: disable=missing-docstri
 
 @instances_of_key.register(LibraryUsageLocator)
 @cacheable
-def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docstring
+def _instances_of_library_usage(cls, **kwargs):
 
     return strategies.builds(
         cls,
@@ -355,7 +354,7 @@ def _instances_of_library_usage(cls, **kwargs):  # pylint: disable=missing-docst
 
 @instances_of_key.register(DeprecatedLocation)
 @cacheable
-def _instances_of_deprecated_loc(cls, **kwargs):  # pylint: disable=missing-docstring
+def _instances_of_deprecated_loc(cls, **kwargs):
 
     return strategies.builds(
         cls,

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = settings.test
-addopts = --cov . --cov-config .coveragerc --pep8 --pylint --cov-report term --cov-report html -n auto
+addopts = --cov . --cov-config .coveragerc --cov-report term --cov-report html -n auto
 norecursedirs = .git .tox .* CVS _darcs {arch} *.egg
 pep8ignore =
     */migrations/* ALL

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -4,3 +4,4 @@
 # migration guide here: https://pymongo.readthedocs.io/en/4.0/migrate-to-pymongo4.html
 pymongo>=2.7.2,<4.0
 stevedore>=0.14.1
+typing-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -10,3 +10,5 @@ pymongo==3.12.3
     # via -r requirements/base.in
 stevedore==4.0.0
     # via -r requirements/base.in
+typing-extensions==4.3.0
+    # via -r requirements/base.in

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -77,6 +77,12 @@ more-itertools==8.14.0
     # via
     #   -r requirements/test.txt
     #   pytest
+mypy==1.4.1
+    # via -r requirements/test.txt
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements/test.txt
+    #   mypy
 packaging==21.3
     # via
     #   -r requirements/test.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -105,6 +105,12 @@ more-itertools==8.14.0
     # via
     #   -r requirements/test.txt
     #   pytest
+mypy==1.4.1
+    # via -r requirements/test.txt
+mypy-extensions==1.0.0
+    # via
+    #   -r requirements/test.txt
+    #   mypy
 packaging==21.3
     # via
     #   -r requirements/test.txt

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -12,6 +12,4 @@ mypy
 pycodestyle
 pytest
 pytest-cov
-pytest-pep8
-pytest-pylint
 pytest-xdist

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -8,6 +8,7 @@ ddt
 edx-lint
 hypothesis
 mock
+mypy
 pycodestyle
 pytest
 pytest-cov

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -63,8 +63,6 @@ pbr==5.10.0
     # via
     #   -r requirements/base.txt
     #   stevedore
-pep8==1.7.1
-    # via pytest-pep8
 platformdirs==2.5.2
     # via pylint
 pluggy==0.13.1
@@ -83,7 +81,6 @@ pylint==2.14.5
     #   pylint-celery
     #   pylint-django
     #   pylint-plugin-utils
-    #   pytest-pylint
 pylint-celery==0.3
     # via edx-lint
 pylint-django==2.5.3
@@ -103,19 +100,11 @@ pytest==5.4.3
     #   pytest-cache
     #   pytest-cov
     #   pytest-forked
-    #   pytest-pep8
-    #   pytest-pylint
     #   pytest-xdist
-pytest-cache==1.0
-    # via pytest-pep8
 pytest-cov==3.0.0
     # via -r requirements/test.in
 pytest-forked==1.4.0
     # via pytest-xdist
-pytest-pep8==1.0.6
-    # via -r requirements/test.in
-pytest-pylint==0.18.0
-    # via -r requirements/test.in
 pytest-xdist==1.34.0
     # via
     #   -c requirements/constraints.txt
@@ -136,8 +125,6 @@ stevedore==4.0.0
     #   code-annotations
 text-unidecode==1.3
     # via python-slugify
-toml==0.10.2
-    # via pytest-pylint
 tomli==2.0.1
     # via
     #   coverage

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -53,6 +53,10 @@ mock==4.0.3
     # via -r requirements/test.in
 more-itertools==8.14.0
     # via pytest
+mypy==1.4.1
+    # via -r requirements/test.in
+mypy-extensions==1.0.0
+    # via mypy
 packaging==21.3
     # via pytest
 pbr==5.10.0

--- a/setup.py
+++ b/setup.py
@@ -108,6 +108,7 @@ setup(
     ],
     # We are including the tests because other libraries do use mixins from them.
     packages=find_packages(),
+    include_package_data=True,
     license='AGPL-3.0',
     install_requires=load_requirements('requirements/base.in'),
     extras_require={

--- a/tox.ini
+++ b/tox.ini
@@ -17,6 +17,7 @@ commands = pytest --disable-pytest-warnings --ignore=opaque_keys/edx/django {pos
 [testenv:quality]
 commands = 
     pycodestyle --config=.pep8 opaque_keys
+    mypy
     pylint --rcfile=pylintrc opaque_keys
 
 [testenv:docs]


### PR DESCRIPTION
This adds type hints to opaque-keys, including to the CI build so that type rules are enforced before PRs can be merged.

This is actually aimed to help with edx-platform development, because once these type hints are in place, mypy can be used to check types of modules in edx-platform - see https://github.com/openedx/edx-platform/pull/32591 for example. Currently mypy just treats any OpaqueKey type as `Any` which is not helpful.

Some of the variables are of type `ObjectId` but this gets broadened automatically to `Any` because we're using an old version of `pymongo` that lacks type annotations. Once we upgrade `pymongo`, we'll have a more specific `ObjectId` type working.

Left for future:
- [ ] Upgrade `pymongo` so we have a working `ObjectId` type