### PR TITLE
fix: type hints weren't installed properly, add type hints for Django Fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+# 2.5.1
+
+* Fixed - py.typed file wasn't installed properly via setuptools
+
 # 2.5.0
 
 * Added python type hints

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 # 2.5.1
 
-* Fixed - py.typed file wasn't installed properly via setuptools
+* Fixed - py.typed file wasn't installed properly via setuptools.
+* Added type hints for the OpaqueKeyField subclasses (requires mypy plugin)
 
 # 2.5.0
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,4 +6,4 @@ include requirements/django.in
 recursive-include opaque_keys *.html *.png *.gif *js *.css *jpg *jpeg *svg *py
 include requirements/constraints.txt
 include requirements/base.txt
-
+include opaque_keys/py.typed

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from functools import total_ordering
 from stevedore.enabled import EnabledExtensionManager
 from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 
 
 class InvalidKeyError(Exception):

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -194,6 +194,12 @@ class LearningContextKeyField(OpaqueKeyField):
     """
     description = "A LearningContextKey object, saved to the DB in the form of a string"
     KEY_CLASS = LearningContextKey
+    # Declare the field types for the django-stubs mypy type hint plugin.
+    # See https://github.com/typeddjango/django-stubs/blob/6a850f6/django-stubs/db/models/fields/__init__.pyi#L503-L511
+    # for examples of how this works for the standard field types in the upstream codebase.
+    # Note that these particular type annotations have no effect at runtime nor on Django itself nor on PyLance.
+    _pyi_private_set_type: LearningContextKey | str | None  # The types that you can set into this field.
+    _pyi_private_get_type: LearningContextKey  # The type that you get when you read from this field
 
 
 class CourseKeyField(OpaqueKeyField):
@@ -202,6 +208,9 @@ class CourseKeyField(OpaqueKeyField):
     """
     description = "A CourseKey object, saved to the DB in the form of a string"
     KEY_CLASS = CourseKey
+    # Declare the field types for the django-stubs mypy type hint plugin:
+    _pyi_private_set_type: CourseKey | str | None
+    _pyi_private_get_type: CourseKey
 
 
 class UsageKeyField(OpaqueKeyField):
@@ -210,6 +219,9 @@ class UsageKeyField(OpaqueKeyField):
     """
     description = "A Location object, saved to the DB in the form of a string"
     KEY_CLASS = UsageKey
+    # Declare the field types for the django-stubs mypy type hint plugin:
+    _pyi_private_set_type: UsageKey | str | None
+    _pyi_private_get_type: UsageKey
 
 
 class LocationKeyField(UsageKeyField):
@@ -228,3 +240,6 @@ class BlockTypeKeyField(OpaqueKeyField):
     """
     description = "A BlockTypeKey object, saved to the DB in the form of a string."
     KEY_CLASS = BlockTypeKey
+    # Declare the field types for the django-stubs mypy type hint plugin:
+    _pyi_private_set_type: BlockTypeKey | str | None
+    _pyi_private_get_type: BlockTypeKey

--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -199,7 +199,7 @@ class LearningContextKeyField(OpaqueKeyField):
     # for examples of how this works for the standard field types in the upstream codebase.
     # Note that these particular type annotations have no effect at runtime nor on Django itself nor on PyLance.
     _pyi_private_set_type: LearningContextKey | str | None  # The types that you can set into this field.
-    _pyi_private_get_type: LearningContextKey  # The type that you get when you read from this field
+    _pyi_private_get_type: LearningContextKey | None  # The type that you get when you read from this field
 
 
 class CourseKeyField(OpaqueKeyField):
@@ -210,7 +210,7 @@ class CourseKeyField(OpaqueKeyField):
     KEY_CLASS = CourseKey
     # Declare the field types for the django-stubs mypy type hint plugin:
     _pyi_private_set_type: CourseKey | str | None
-    _pyi_private_get_type: CourseKey
+    _pyi_private_get_type: CourseKey | None
 
 
 class UsageKeyField(OpaqueKeyField):
@@ -221,7 +221,7 @@ class UsageKeyField(OpaqueKeyField):
     KEY_CLASS = UsageKey
     # Declare the field types for the django-stubs mypy type hint plugin:
     _pyi_private_set_type: UsageKey | str | None
-    _pyi_private_get_type: UsageKey
+    _pyi_private_get_type: UsageKey | None
 
 
 class LocationKeyField(UsageKeyField):
@@ -242,4 +242,4 @@ class BlockTypeKeyField(OpaqueKeyField):
     KEY_CLASS = BlockTypeKey
     # Declare the field types for the django-stubs mypy type hint plugin:
     _pyi_private_set_type: BlockTypeKey | str | None
-    _pyi_private_get_type: BlockTypeKey
+    _pyi_private_get_type: BlockTypeKey | None


### PR DESCRIPTION
My last PR #256 wasn't *quite* working with `mypy` in edx-platform. It was working fine in "editable" mode with `python setup.py develop` or `pip install -e .` but when installed via `pip install edx-opaque-keys==2.5.0` or `python setup.py install`, the important `py.typed` marker file was missing.

I thought that using `include_package_data=True` was sufficient, but it turns out I also needed to add a line to `MANIFEST.in`.

With this change, the `py.typed` file is installed and mypy will use the type hints added in #256.

------

I also added type hints for the django fields like `UsageKeyField`. This only works because of the django-stubs mypy plugin that we use in edx-platform, and requires setting a "private" class attribute to define the types, but it seems to work very well. Now mypy is aware that reading from a `UsageKeyField` will result in a `UsageKey` and writing to one accepts a `UsageKey` or `str` or `None`.  (Keep in mind these additional static fields are type-only and will be ignored at runtime; they only affect mypy and then only if the django-stubs mypy plugin is installed.)