### PR TITLE
build: Update upgrade-python-requirements.yml

### DIFF
--- a/.github/workflows/upgrade-python-requirements.yml
+++ b/.github/workflows/upgrade-python-requirements.yml
@@ -8,7 +8,7 @@ on:
       branch:
         description: "Target branch against which to create requirements PR"
         required: true
-        default: '$default-branch'
+        default: 'master'
 
 jobs:
   call-upgrade-python-requirements-workflow:


### PR DESCRIPTION
Using the `$default-branch' variable doesn't work as a `default` value for a workflow input.