### PR TITLE
fix: remove tox-battery and update tox

### DIFF
--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -3,4 +3,3 @@
 
 coverage                  # Be able to generate coverage data.
 tox                       # Virtualenv management for tests
-tox-battery               # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -29,10 +29,6 @@ six==1.16.0
 tomli==2.0.1
     # via tox
 tox==3.28.0
-    # via
-    #   -r requirements/ci.in
-    #   tox-battery
-tox-battery==0.6.2
     # via -r requirements/ci.in
 virtualenv==20.25.0
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -330,10 +330,6 @@ tomlkit==0.12.3
     #   -r requirements/doc.txt
     #   pylint
 tox==3.28.0
-    # via
-    #   -r requirements/ci.txt
-    #   tox-battery
-tox-battery==0.6.2
     # via -r requirements/ci.txt
 typing-extensions==4.8.0
     # via


### PR DESCRIPTION
## Description
- Removed `tox-battery` from requirements and updated `tox` to `v4`.