### PR TITLE
build: Add a long_descriptino which is now a required field.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
 
     - name: Run Coverage
       if: matrix.python-version == '3.11' && matrix.toxenv=='django42'
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4
       with:
         flags: unittests
         fail_ci_if_error: true
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from functools import total_ordering
 from stevedore.enabled import EnabledExtensionManager
 from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
-__version__ = '2.7.0'
+__version__ = '2.8.0'
 
 
 class InvalidKeyError(Exception):

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ Package metadata for edx-opaque-keys.
 """
 import os
 import re
+from pathlib import Path
 
 from setuptools import find_packages, setup
 
@@ -90,9 +91,15 @@ def get_version(*file_paths):
 
 VERSION = get_version("opaque_keys", "__init__.py")
 
+# read the contents of your README file
+this_directory = Path(__file__).parent
+long_description = (this_directory / "README.rst").read_text()
+
 
 setup(
     name='edx-opaque-keys',
+    long_description=long_description,
+    long_description_content_type='text/x-rst',
     version=VERSION,
     author='edX',
     url='https://github.com/openedx/opaque-keys',
@@ -105,8 +112,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Framework :: Django",
-        "Framework :: Django :: 3.2",
-        "Framework :: Django :: 4.0",
+        "Framework :: Django :: 4.2",
     ],
     # We are including the tests because other libraries do use mixins from them.
     packages=find_packages(),


### PR DESCRIPTION
Previously it could be empty but now PyPI throws an error when you try
to publish with an empty long description.

Fix that, and bump the version.  We're also updating the django
classifiers to be more accurate.
