### PR TITLE
feanil/unpin pymongo

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+# 2.10.0
+
+* Unpin pymongo and upgrade to the latest available version.
+
 # 2.9.0
 
 * Upgrade pymongo to 4.4. It contains few breaking changes.

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from functools import total_ordering
 from stevedore.enabled import EnabledExtensionManager
 from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
-__version__ = '2.9.0'
+__version__ = '2.10.0'
 
 
 class InvalidKeyError(Exception):

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -2,6 +2,6 @@
 -c constraints.txt
 
 # https://pymongo.readthedocs.io/en/4.4.0/migrate-to-pymongo4.html#son-items-now-returns-dict-items-object
-pymongo>=2.7.2,<4.4.1
+pymongo
 stevedore>=0.14.1
 typing-extensions

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,9 +8,9 @@ dnspython==2.6.1
     # via pymongo
 pbr==6.0.0
     # via stevedore
-pymongo==4.4.0
+pymongo==4.7.3
     # via -r requirements/base.in
 stevedore==5.2.0
     # via -r requirements/base.in
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via -r requirements/base.in

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -34,7 +34,7 @@ tomli==2.0.1
     # via
     #   pyproject-api
     #   tox
-tox==4.15.0
+tox==4.15.1
     # via -r requirements/ci.in
 virtualenv==20.26.2
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -38,7 +38,7 @@ cachetools==5.3.3
     # via
     #   -r requirements/ci.txt
     #   tox
-certifi==2024.2.2
+certifi==2024.6.2
     # via
     #   -r requirements/doc.txt
     #   requests
@@ -111,7 +111,7 @@ filelock==3.14.0
     #   -r requirements/ci.txt
     #   tox
     #   virtualenv
-hypothesis==6.103.0
+hypothesis==6.103.1
     # via -r requirements/doc.txt
 idna==3.7
     # via
@@ -203,7 +203,7 @@ pygments==2.18.0
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
-pylint==3.2.2
+pylint==3.2.3
     # via
     #   -r requirements/doc.txt
     #   edx-lint
@@ -223,7 +223,7 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/doc.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pymongo==4.7.3
     # via -r requirements/doc.txt
 pyproject-api==1.6.1
     # via
@@ -234,7 +234,7 @@ pyproject-hooks==1.1.0
     #   -r requirements/pip-tools.txt
     #   build
     #   pip-tools
-pytest==8.2.1
+pytest==8.2.2
     # via
     #   -r requirements/doc.txt
     #   pytest-cov
@@ -333,9 +333,9 @@ tomlkit==0.12.5
     # via
     #   -r requirements/doc.txt
     #   pylint
-tox==4.15.0
+tox==4.15.1
     # via -r requirements/ci.txt
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via
     #   -r requirements/doc.txt
     #   astroid
@@ -354,7 +354,7 @@ wheel==0.43.0
     # via
     #   -r requirements/pip-tools.txt
     #   pip-tools
-zipp==3.19.0
+zipp==3.19.2
     # via
     #   -r requirements/doc.txt
     #   -r requirements/pip-tools.txt

--- a/requirements/django-test.txt
+++ b/requirements/django-test.txt
@@ -52,7 +52,7 @@ execnet==2.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-xdist
-hypothesis==6.103.0
+hypothesis==6.103.1
     # via -r requirements/test.txt
 iniconfig==2.0.0
     # via
@@ -100,7 +100,7 @@ pluggy==1.5.0
     #   pytest
 pycodestyle==2.11.1
     # via -r requirements/test.txt
-pylint==3.2.2
+pylint==3.2.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -120,9 +120,9 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pymongo==4.7.3
     # via -r requirements/test.txt
-pytest==8.2.1
+pytest==8.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -169,7 +169,7 @@ tomlkit==0.12.5
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via
     #   -r requirements/test.txt
     #   astroid

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -23,7 +23,7 @@ babel==2.15.0
     #   sphinx
 beautifulsoup4==4.12.3
     # via pydata-sphinx-theme
-certifi==2024.2.2
+certifi==2024.6.2
     # via requests
 charset-normalizer==3.3.2
     # via requests
@@ -71,7 +71,7 @@ execnet==2.1.1
     # via
     #   -r requirements/test.txt
     #   pytest-xdist
-hypothesis==6.103.0
+hypothesis==6.103.1
     # via -r requirements/test.txt
 idna==3.7
     # via requests
@@ -138,7 +138,7 @@ pygments==2.18.0
     #   pydata-sphinx-theme
     #   readme-renderer
     #   sphinx
-pylint==3.2.2
+pylint==3.2.3
     # via
     #   -r requirements/test.txt
     #   edx-lint
@@ -158,9 +158,9 @@ pylint-plugin-utils==0.8.2
     #   -r requirements/test.txt
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pymongo==4.7.3
     # via -r requirements/test.txt
-pytest==8.2.1
+pytest==8.2.2
     # via
     #   -r requirements/test.txt
     #   pytest-cov
@@ -233,7 +233,7 @@ tomlkit==0.12.5
     # via
     #   -r requirements/test.txt
     #   pylint
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via
     #   -r requirements/test.txt
     #   astroid
@@ -242,5 +242,5 @@ typing-extensions==4.12.0
     #   pylint
 urllib3==2.2.1
     # via requests
-zipp==3.19.0
+zipp==3.19.2
     # via importlib-metadata

--- a/requirements/pip-tools.txt
+++ b/requirements/pip-tools.txt
@@ -24,7 +24,7 @@ tomli==2.0.1
     #   pip-tools
 wheel==0.43.0
     # via pip-tools
-zipp==3.19.0
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -39,7 +39,7 @@ exceptiongroup==1.2.1
     #   pytest
 execnet==2.1.1
     # via pytest-xdist
-hypothesis==6.103.0
+hypothesis==6.103.1
     # via -r requirements/test.in
 iniconfig==2.0.0
     # via pytest
@@ -69,7 +69,7 @@ pluggy==1.5.0
     # via pytest
 pycodestyle==2.11.1
     # via -r requirements/test.in
-pylint==3.2.2
+pylint==3.2.3
     # via
     #   edx-lint
     #   pylint-celery
@@ -83,9 +83,9 @@ pylint-plugin-utils==0.8.2
     # via
     #   pylint-celery
     #   pylint-django
-pymongo==4.4.0
+pymongo==4.7.3
     # via -r requirements/base.txt
-pytest==8.2.1
+pytest==8.2.2
     # via
     #   -r requirements/test.in
     #   pytest-cov
@@ -116,7 +116,7 @@ tomli==2.0.1
     #   pytest
 tomlkit==0.12.5
     # via pylint
-typing-extensions==4.12.0
+typing-extensions==4.12.2
     # via
     #   -r requirements/base.txt
     #   astroid


### PR DESCRIPTION
- **fix: Unpin Pymongo.**
  - We only use very simple objects from pymongo in this repo and none of
    them have changes in the intermediate versions.  The only usage of the
    SON object is to instantiate one and so no code in this repo is going to
    break by this upgrade.

    There may be other repos that upstream that might need to pin pymongo
    based on their usage but it shouldn't be pinned here.
- **chore: Run `make upgrade`**
