### PR TITLE
feat: Create `LibraryContainerLocator` for Library Containers [FC-0083]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 # 2.12.0
 
-* Refactor: Rename LibraryCollectionKey to LibraryElementKey.
+* Refactor: Rename LibraryCollectionKey to LibraryItemKey.
 * Added LibraryContainerLocator.
 
 # 2.11.0

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+# 2.12.0
+
+* Refactor: Rename LibraryCollectionKey to LibraryElementKey.
+* Added LibraryContainerLocator.
+
 # 2.11.0
 
 * Added LibraryCollectionKey and LibraryCollectionLocator

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -188,6 +188,9 @@ class OpaqueKey(metaclass=OpaqueKeyMetaclass):
         try:
             namespace, rest = cls._separate_namespace(serialized)
             key_class = cls.get_namespace_plugin(namespace)
+            print("OOOOOOOOOOOO")
+            print(key_class)
+            print(cls)
             if not issubclass(key_class, cls):
                 # CourseKey.from_string() should never return a non-course LearningContextKey,
                 # but they share the same namespace.
@@ -233,6 +236,11 @@ class OpaqueKey(metaclass=OpaqueKeyMetaclass):
         # Ensure all extensions are loaded. Extensions may modify the deprecated_fallback attribute of the class, so
         # they must be loaded before processing any keys.
         drivers = cls._drivers()
+
+        print("IIIIIIIIIIIIIII")
+        print(namespace)
+        print(drivers)
+        print(drivers.__dict__)
 
         try:
             return drivers[namespace].plugin

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from functools import total_ordering
 from stevedore.enabled import EnabledExtensionManager
 from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
-__version__ = '2.11.0'
+__version__ = '2.12.0'
 
 
 class InvalidKeyError(Exception):

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -188,9 +188,6 @@ class OpaqueKey(metaclass=OpaqueKeyMetaclass):
         try:
             namespace, rest = cls._separate_namespace(serialized)
             key_class = cls.get_namespace_plugin(namespace)
-            print("OOOOOOOOOOOO")
-            print(key_class)
-            print(cls)
             if not issubclass(key_class, cls):
                 # CourseKey.from_string() should never return a non-course LearningContextKey,
                 # but they share the same namespace.
@@ -236,11 +233,6 @@ class OpaqueKey(metaclass=OpaqueKeyMetaclass):
         # Ensure all extensions are loaded. Extensions may modify the deprecated_fallback attribute of the class, so
         # they must be loaded before processing any keys.
         drivers = cls._drivers()
-
-        print("IIIIIIIIIIIIIII")
-        print(namespace)
-        print(drivers)
-        print(drivers.__dict__)
 
         try:
             return drivers[namespace].plugin

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -93,10 +93,9 @@ class CourseKey(LearningContextKey):
         raise NotImplementedError()
 
 
-class LibraryElementKey(OpaqueKey):
+class LibraryItemKey(OpaqueKey):
     """
-    An :class:`opaque_keys.OpaqueKey` identifying a particular element in a library
-    that is not an Xblock.
+    An :class:`opaque_keys.OpaqueKey` identifying a particular item in a library.
     """
     KEY_TYPE = 'library_element_key'
     library_key: LibraryLocatorV2

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -103,11 +103,12 @@ class LibraryElementKey(OpaqueKey):
     __slots__ = ()
 
     @property
+    @abstractmethod
     def org(self) -> str | None:  # pragma: no cover
         """
         The organization that this object belongs to.
         """
-        return self.library_key.org
+        raise NotImplementedError()
 
 
 class DefinitionKey(OpaqueKey):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -97,7 +97,7 @@ class LibraryItemKey(OpaqueKey):
     """
     An :class:`opaque_keys.OpaqueKey` identifying a particular item in a library.
     """
-    KEY_TYPE = 'library_element_key'
+    KEY_TYPE = 'library_item_key'
     library_key: LibraryLocatorV2
     __slots__ = ()
 

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -93,21 +93,21 @@ class CourseKey(LearningContextKey):
         raise NotImplementedError()
 
 
-class LibraryCollectionKey(OpaqueKey):
+class LibraryElementKey(OpaqueKey):
     """
-    An :class:`opaque_keys.OpaqueKey` identifying a particular Library Collection object.
+    An :class:`opaque_keys.OpaqueKey` identifying a particular element in a library
+    that is not an Xblock.
     """
-    KEY_TYPE = 'collection_key'
+    KEY_TYPE = 'library_element_key'
     library_key: LibraryLocatorV2
-    collection_id: str
     __slots__ = ()
 
     @property
     def org(self) -> str | None:  # pragma: no cover
         """
-        The organization that this collection belongs to.
+        The organization that this object belongs to.
         """
-        raise NotImplementedError()
+        return self.library_key.org
 
 
 class DefinitionKey(OpaqueKey):

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -16,7 +16,7 @@ from typing_extensions import Self  # For python 3.11 plus, can just use "from t
 
 from opaque_keys import OpaqueKey, InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey, DefinitionKey, \
-    LearningContextKey, UsageKey, UsageKeyV2, LibraryElementKey
+    LearningContextKey, UsageKey, UsageKeyV2, LibraryItemKey
 
 log = logging.getLogger(__name__)
 
@@ -1623,7 +1623,7 @@ class LibraryUsageLocatorV2(CheckFieldMixin, UsageKeyV2):
         return str(self)
 
 
-class LibraryCollectionLocator(CheckFieldMixin, LibraryElementKey):
+class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
     """
     When serialized, these keys look like:
         lib-collection:org:lib:collection-id
@@ -1654,7 +1654,7 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryElementKey):
     @property
     def org(self) -> str | None:  # pragma: no cover
         """
-        The organization that this object belongs to.
+        The organization that this Collection belongs to.
         """
         return self.library_key.org
 
@@ -1677,7 +1677,7 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryElementKey):
             raise InvalidKeyError(cls, serialized) from error
 
 
-class LibraryContainerLocator(CheckFieldMixin, LibraryElementKey):
+class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     """
     When serialized, these keys look like:
         lct:org:lib:ct-type:ct-id
@@ -1711,7 +1711,7 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryElementKey):
     @property
     def org(self) -> str | None:  # pragma: no cover
         """
-        The organization that this object belongs to.
+        The organization that this Container belongs to.
         """
         return self.library_key.org
 

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -16,7 +16,7 @@ from typing_extensions import Self  # For python 3.11 plus, can just use "from t
 
 from opaque_keys import OpaqueKey, InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey, DefinitionKey, \
-    LearningContextKey, UsageKey, UsageKeyV2, LibraryCollectionKey
+    LearningContextKey, UsageKey, UsageKeyV2, LibraryElementKey
 
 log = logging.getLogger(__name__)
 
@@ -1623,14 +1623,13 @@ class LibraryUsageLocatorV2(CheckFieldMixin, UsageKeyV2):
         return str(self)
 
 
-class LibraryCollectionLocator(CheckFieldMixin, LibraryCollectionKey):
+class LibraryCollectionLocator(CheckFieldMixin, LibraryElementKey):
     """
     When serialized, these keys look like:
         lib-collection:org:lib:collection-id
     """
     CANONICAL_NAMESPACE = 'lib-collection'
     KEY_FIELDS = ('library_key', 'collection_id')
-    library_key: LibraryLocatorV2
     collection_id: str
 
     __slots__ = KEY_FIELDS
@@ -1646,18 +1645,11 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryCollectionKey):
         if not isinstance(library_key, LibraryLocatorV2):
             raise TypeError("library_key must be a LibraryLocatorV2")
 
-        self._check_key_string_field("collection_id", collection_id, regexp=self.COLLECTION_ID_REGEXP)
+        self._check_key_string_field("object_id", collection_id, regexp=self.COLLECTION_ID_REGEXP)
         super().__init__(
             library_key=library_key,
             collection_id=collection_id,
         )
-
-    @property
-    def org(self) -> str | None:  # pragma: no cover
-        """
-        The organization that this collection belongs to.
-        """
-        return self.library_key.org
 
     def _to_string(self) -> str:
         """

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1651,6 +1651,13 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryElementKey):
             collection_id=collection_id,
         )
 
+    @property
+    def org(self) -> str | None:  # pragma: no cover
+        """
+        The organization that this object belongs to.
+        """
+        return self.library_key.org
+
     def _to_string(self) -> str:
         """
         Serialize this key as a string
@@ -1700,6 +1707,13 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryElementKey):
             container_type=container_type,
             container_id=container_id,
         )
+
+    @property
+    def org(self) -> str | None:  # pragma: no cover
+        """
+        The organization that this object belongs to.
+        """
+        return self.library_key.org
 
     def _to_string(self) -> str:
         """

--- a/opaque_keys/edx/tests/test_container_locators.py
+++ b/opaque_keys/edx/tests/test_container_locators.py
@@ -1,0 +1,75 @@
+"""
+Tests of LibraryContainerLocator
+"""
+import ddt
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.tests import LocatorBaseTest
+from opaque_keys.edx.locator import LibraryContainerLocator, LibraryLocatorV2
+
+
+@ddt.ddt
+class TestLibraryContainerLocator(LocatorBaseTest):
+    """
+    Tests of :class:`.LibraryContainerLocator`
+    """
+    @ddt.data(
+        "org/lib/id/foo",
+        "org/lib/id",
+        "org+lib+id",
+        "org+lib+",
+        "org+lib++id@library",
+        "org+ne@t",
+        "per%ent+sign",
+    )
+    def test_coll_key_from_invalid_string(self, coll_id_str):
+        with self.assertRaises(InvalidKeyError):
+            LibraryContainerLocator.from_string(coll_id_str)
+
+    def test_key_constructor(self):
+        org = 'TestX'
+        lib = 'LibraryX'
+        container_type = 'unit'
+        container_id = 'test-container'
+        library_key = LibraryLocatorV2(org=org, slug=lib)
+        container_key = LibraryContainerLocator(
+            library_key=library_key,
+            container_type=container_type,
+            container_id=container_id,
+        )
+        library_key = container_key.library_key
+        self.assertEqual(str(container_key), "lct:TestX:LibraryX:unit:test-container")
+        self.assertEqual(container_key.org, org)
+        self.assertEqual(container_key.container_type, container_type)
+        self.assertEqual(container_key.container_id, container_id)
+        self.assertEqual(library_key.org, org)
+        self.assertEqual(library_key.slug, lib)
+
+    def test_key_constructor_bad_ids(self):
+        library_key = LibraryLocatorV2(org="TestX", slug="lib1")
+
+        with self.assertRaises(TypeError):
+            LibraryContainerLocator(library_key=None, container_type='unit', container_id='usage')
+
+        with self.assertRaises(ValueError):
+            LibraryContainerLocator(library_key=library_key, container_type='unit', container_id='usage-!@#{$%^&*}')
+
+    def test_key_constructor_bad_type(self):
+        library_key = LibraryLocatorV2(org="TestX", slug="lib1")
+
+        with self.assertRaises(ValueError):
+            LibraryContainerLocator(library_key=library_key, container_type='unit-!@#{$%^&*}', container_id='usage')
+
+    def test_key_from_string(self):
+        org = 'TestX'
+        lib = 'LibraryX'
+        container_type = 'unit'
+        container_id = 'test-container'
+        str_key = f"lct:{org}:{lib}:{container_type}:{container_id}"
+        container_key = LibraryContainerLocator.from_string(str_key)
+        library_key = container_key.library_key
+        self.assertEqual(str(container_key), str_key)
+        self.assertEqual(container_key.org, org)
+        self.assertEqual(container_key.container_type, container_type)
+        self.assertEqual(container_key.container_id, container_id)
+        self.assertEqual(library_key.org, org)
+        self.assertEqual(library_key.slug, lib)

--- a/setup.py
+++ b/setup.py
@@ -183,8 +183,9 @@ setup(
         'block_type': [
             'block-type-v1 = opaque_keys.edx.block_types:BlockTypeKeyV1',
         ],
-        'collection_key': [
+        'library_element_key': [
             'lib-collection = opaque_keys.edx.locator:LibraryCollectionLocator',
+            'lct = opaque_keys.edx.locator:LibraryContainerLocator',
         ],
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ setup(
         'block_type': [
             'block-type-v1 = opaque_keys.edx.block_types:BlockTypeKeyV1',
         ],
-        'library_element_key': [
+        'library_item_key': [
             'lib-collection = opaque_keys.edx.locator:LibraryCollectionLocator',
             'lct = opaque_keys.edx.locator:LibraryContainerLocator',
         ],


### PR DESCRIPTION
## Description

- Refactor `LibraryCollectionKey` to `LibraryItemKey` to use it as the general class for `LibraryCollectionLocator` and `LibraryContainerLocator`.
- Creation of `LibraryContainerLocator`
- Add `LibraryUsageLocatorV2` also as `LibraryItemKey`

## Support Information

- Github issues:
    - https://github.com/openedx/openedx-learning/issues/282
    - https://github.com/openedx/frontend-app-authoring/issues/1704
- Used in: https://github.com/openedx/edx-platform/pull/36379
- Internal ticket: [FAL-4108](https://tasks.opencraft.com/browse/FAL-4108)

## Testing instructions

- Check all the code.
- Verify that the test covers the changes.
