### PR TITLE
feat: context key property for new container locator keys

### DIFF
--- a/opaque_keys/edx/django/models.py
+++ b/opaque_keys/edx/django/models.py
@@ -3,6 +3,7 @@ Useful django models for implementing XBlock infrastructure in django.
 If Django is unavailable, none of the classes below will work as intended.
 """
 from __future__ import annotations
+
 import logging
 import warnings
 
@@ -17,8 +18,7 @@ except ImportError:  # pragma: no cover
     IsNull = object
 
 from opaque_keys import OpaqueKey
-from opaque_keys.edx.keys import BlockTypeKey, CourseKey, LearningContextKey, UsageKey
-
+from opaque_keys.edx.keys import BlockTypeKey, CourseKey, LearningContextKey, LibraryItemKey, UsageKey
 
 log = logging.getLogger(__name__)
 
@@ -222,6 +222,17 @@ class UsageKeyField(OpaqueKeyField):
     # Declare the field types for the django-stubs mypy type hint plugin:
     _pyi_private_set_type: UsageKey | str | None
     _pyi_private_get_type: UsageKey | None
+
+
+class LibraryItemField(OpaqueKeyField):
+    """
+    A django Field that stores a LibraryItemKey object as a string.
+    """
+    description = "A Location object, saved to the DB in the form of a string"
+    KEY_CLASS = LibraryItemKey
+    # Declare the field types for the django-stubs mypy type hint plugin:
+    _pyi_private_set_type: LibraryItemKey | str | None
+    _pyi_private_get_type: LibraryItemKey | None
 
 
 class LocationKeyField(UsageKeyField):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -114,6 +114,15 @@ class LibraryItemKey(OpaqueKey):
     def library_key(self):
         return self.lib_key
 
+    @property
+    @abstractmethod
+    def context_key(self) -> LearningContextKey:
+        """
+        Get the learning context key (LearningContextKey) for this XBlock usage.
+        May be a course key, library key, or some other LearningContextKey type.
+        """
+        raise NotImplementedError()
+
 
 class DefinitionKey(OpaqueKey):
     """

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -118,7 +118,7 @@ class LibraryItemKey(OpaqueKey):
     @abstractmethod
     def context_key(self) -> LearningContextKey:
         """
-        Get the learning context key (LearningContextKey) for this item key.
+        Get the learning context key (LearningContextKey) for this XBlock usage.
         May be a course key, library key, or some other LearningContextKey type.
         """
         raise NotImplementedError()

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -118,7 +118,7 @@ class LibraryItemKey(OpaqueKey):
     @abstractmethod
     def context_key(self) -> LearningContextKey:
         """
-        Get the learning context key (LearningContextKey) for this XBlock usage.
+        Get the learning context key (LearningContextKey) for this item key.
         May be a course key, library key, or some other LearningContextKey type.
         """
         raise NotImplementedError()

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1675,6 +1675,10 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         except (ValueError, TypeError) as error:
             raise InvalidKeyError(cls, serialized) from error
 
+    @property
+    def context_key(self) -> LibraryLocatorV2:
+        return self.library_key
+
 
 class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     """
@@ -1713,6 +1717,10 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
         The organization that this Container belongs to.
         """
         return self.lib_key.org
+
+    @property
+    def context_key(self) -> LibraryLocatorV2:
+        return self.library_key
 
     def _to_string(self) -> str:
         """

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1680,6 +1680,13 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         return self.library_key
 
 
+class LibraryContainerUsageLocator(LibraryUsageLocatorV2):
+    """
+    Virtual usage_key to represet LibraryContainerLocator
+    """
+    CANONICAL_NAMESPACE = 'lb-mapped'
+
+
 class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     """
     When serialized, these keys look like:
@@ -1721,6 +1728,25 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     @property
     def context_key(self) -> LibraryLocatorV2:
         return self.library_key
+
+    @property
+    def lib_usage_key(self) -> LibraryContainerUsageLocator:
+        usage_key = LibraryContainerUsageLocator(
+            lib_key=self.library_key,
+            block_type=self.container_type,
+            usage_id=self.container_id,
+        )
+        return usage_key
+
+    @classmethod
+    def from_usage_key(cls, usage_key: LibraryContainerUsageLocator) -> Self:
+        if not isinstance(usage_key, LibraryContainerUsageLocator):
+            raise InvalidKeyError(cls, str(usage_key))
+        try:
+            key_str = str(usage_key).replace(LibraryContainerUsageLocator.CANONICAL_NAMESPACE, cls.CANONICAL_NAMESPACE, 1)
+            return cls.from_string(key_str)
+        except (ValueError, TypeError) as error:
+            raise InvalidKeyError(cls, str(usage_key)) from error
 
     def _to_string(self) -> str:
         """

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1677,7 +1677,7 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
 
     @property
     def context_key(self) -> LibraryLocatorV2:
-        return self.library_key
+        return self.lib_key
 
 
 class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
@@ -1720,7 +1720,7 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
 
     @property
     def context_key(self) -> LibraryLocatorV2:
-        return self.library_key
+        return self.lib_key
 
     def _to_string(self) -> str:
         """

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1680,13 +1680,6 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         return self.library_key
 
 
-class LibraryContainerUsageLocator(LibraryUsageLocatorV2):
-    """
-    Virtual usage_key to represet LibraryContainerLocator
-    """
-    CANONICAL_NAMESPACE = 'lb-mapped'
-
-
 class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     """
     When serialized, these keys look like:
@@ -1728,25 +1721,6 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     @property
     def context_key(self) -> LibraryLocatorV2:
         return self.library_key
-
-    @property
-    def lib_usage_key(self) -> LibraryContainerUsageLocator:
-        usage_key = LibraryContainerUsageLocator(
-            lib_key=self.library_key,
-            block_type=self.container_type,
-            usage_id=self.container_id,
-        )
-        return usage_key
-
-    @classmethod
-    def from_usage_key(cls, usage_key: LibraryContainerUsageLocator) -> Self:
-        if not isinstance(usage_key, LibraryContainerUsageLocator):
-            raise InvalidKeyError(cls, str(usage_key))
-        try:
-            key_str = str(usage_key).replace(LibraryContainerUsageLocator.CANONICAL_NAMESPACE, cls.CANONICAL_NAMESPACE, 1)
-            return cls.from_string(key_str)
-        except (ValueError, TypeError) as error:
-            raise InvalidKeyError(cls, str(usage_key)) from error
 
     def _to_string(self) -> str:
         """

--- a/setup.py
+++ b/setup.py
@@ -167,7 +167,6 @@ setup(
             'block-v1 = opaque_keys.edx.locator:BlockUsageLocator',
             'lib-block-v1 = opaque_keys.edx.locator:LibraryUsageLocator',
             'lb = opaque_keys.edx.locator:LibraryUsageLocatorV2',
-            'lb-mapped = opaque_keys.edx.locator:LibraryContainerUsageLocator',
             'location = opaque_keys.edx.locations:DeprecatedLocation',
             'aside-usage-v1 = opaque_keys.edx.asides:AsideUsageKeyV1',
             'aside-usage-v2 = opaque_keys.edx.asides:AsideUsageKeyV2',

--- a/setup.py
+++ b/setup.py
@@ -167,6 +167,7 @@ setup(
             'block-v1 = opaque_keys.edx.locator:BlockUsageLocator',
             'lib-block-v1 = opaque_keys.edx.locator:LibraryUsageLocator',
             'lb = opaque_keys.edx.locator:LibraryUsageLocatorV2',
+            'lb-mapped = opaque_keys.edx.locator:LibraryContainerUsageLocator',
             'location = opaque_keys.edx.locations:DeprecatedLocation',
             'aside-usage-v1 = opaque_keys.edx.asides:AsideUsageKeyV1',
             'aside-usage-v2 = opaque_keys.edx.asides:AsideUsageKeyV2',


### PR DESCRIPTION
1. _All_ keys for content items inside a learning context should have the `.context_key` property to get the parent learning context, but some of the new library keys were missing this.

2. Adds a new Django field type that can store `LibraryItemKey` (Collection or Container keys). (TODO: this should probably be able to hold library usage keys too, since those are also library items)