### PR TITLE
feat: rename 'library_key' to 'lib_key' on v2 locators for consistency [FC-0083]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+# 2.13.0
+
+* Breaking change to the new LibraryContainerLocator and
+  LibraryCollectionLocator keys: rename 'library_key' to 'lib_key'
+* Updated some imports now that we require python 3.11+
+
 # 2.12.0
 
 * Refactor: Rename LibraryCollectionKey to LibraryItemKey.

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 from abc import ABCMeta, abstractmethod
 from collections import defaultdict
 from functools import total_ordering
+from typing import Self
 
 from stevedore.enabled import EnabledExtensionManager
-from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
 __version__ = '2.12.0'
 

--- a/opaque_keys/__init__.py
+++ b/opaque_keys/__init__.py
@@ -14,7 +14,7 @@ from typing import Self
 
 from stevedore.enabled import EnabledExtensionManager
 
-__version__ = '2.12.0'
+__version__ = '2.13.0'
 
 
 class InvalidKeyError(Exception):

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -4,10 +4,10 @@ OpaqueKey abstract classes for edx-platform object types (courses, definitions, 
 from __future__ import annotations
 import json
 from abc import abstractmethod
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Self
 import warnings
 
-from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
+from typing_extensions import deprecated  # For python 3.13+ can use 'from warnings import deprecated'
 
 from opaque_keys import OpaqueKey
 
@@ -98,7 +98,7 @@ class LibraryItemKey(OpaqueKey):
     An :class:`opaque_keys.OpaqueKey` identifying a particular item in a library.
     """
     KEY_TYPE = 'library_item_key'
-    library_key: LibraryLocatorV2
+    lib_key: LibraryLocatorV2
     __slots__ = ()
 
     @property
@@ -108,6 +108,11 @@ class LibraryItemKey(OpaqueKey):
         The organization that this object belongs to.
         """
         raise NotImplementedError()
+
+    @property
+    @deprecated("Use lib_key instead")
+    def library_key(self):
+        return self.lib_key
 
 
 class DefinitionKey(OpaqueKey):

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 import inspect
 import logging
 import re
-from typing import Any
+from typing import Any, Self
 import warnings
 from uuid import UUID
 
 from bson.errors import InvalidId
 from bson.objectid import ObjectId
 from bson.son import SON
-from typing_extensions import Self  # For python 3.11 plus, can just use "from typing import Self"
 
 from opaque_keys import OpaqueKey, InvalidKeyError
 from opaque_keys.edx.keys import AssetKey, CourseKey, DefinitionKey, \

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -412,8 +412,8 @@ LearningContextKey.set_deprecated_fallback(CourseLocator)
 
 class LibraryLocator(BlockLocatorBase, CourseKey):
     """
-    Locates a library. Libraries are XBlock structures with a 'library' block
-    at their root.
+    Locates a legacy (v1) library. Legacy libraries are XBlock structures with a
+    'library' block at their root.
 
     Libraries are treated analogously to courses for now. Once opaque keys are
     better supported, they will no longer have the 'run' property, and may no
@@ -1065,8 +1065,8 @@ UsageKey.set_deprecated_fallback(BlockUsageLocator)
 
 class LibraryUsageLocator(BlockUsageLocator):
     """
-    Just like BlockUsageLocator, but this points to a block stored in a library,
-    not a course.
+    Just like BlockUsageLocator, but this points to a block stored in a legacy
+    (v1) modulestore library.
     """
     CANONICAL_NAMESPACE = 'lib-block-v1'
     KEY_FIELDS = ('library_key', 'block_type', 'block_id')
@@ -1629,7 +1629,7 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         lib-collection:org:lib:collection-id
     """
     CANONICAL_NAMESPACE = 'lib-collection'
-    KEY_FIELDS = ('library_key', 'collection_id')
+    KEY_FIELDS = ('lib_key', 'collection_id')
     collection_id: str
 
     __slots__ = KEY_FIELDS
@@ -1638,16 +1638,16 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
     # Allow collection IDs to contian unicode characters
     COLLECTION_ID_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)
 
-    def __init__(self, library_key: LibraryLocatorV2, collection_id: str):
+    def __init__(self, lib_key: LibraryLocatorV2, collection_id: str):
         """
         Construct a CollectionLocator
         """
-        if not isinstance(library_key, LibraryLocatorV2):
-            raise TypeError("library_key must be a LibraryLocatorV2")
+        if not isinstance(lib_key, LibraryLocatorV2):
+            raise TypeError("lib_key must be a LibraryLocatorV2")
 
         self._check_key_string_field("collection_id", collection_id, regexp=self.COLLECTION_ID_REGEXP)
         super().__init__(
-            library_key=library_key,
+            lib_key=lib_key,
             collection_id=collection_id,
         )
 
@@ -1656,13 +1656,13 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         """
         The organization that this Collection belongs to.
         """
-        return self.library_key.org
+        return self.lib_key.org
 
     def _to_string(self) -> str:
         """
         Serialize this key as a string
         """
-        return ":".join((self.library_key.org, self.library_key.slug, self.collection_id))
+        return ":".join((self.lib_key.org, self.lib_key.slug, self.collection_id))
 
     @classmethod
     def _from_string(cls, serialized: str) -> Self:
@@ -1671,8 +1671,8 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         """
         try:
             (org, lib_slug, collection_id) = serialized.split(':')
-            library_key = LibraryLocatorV2(org, lib_slug)
-            return cls(library_key, collection_id)
+            lib_key = LibraryLocatorV2(org, lib_slug)
+            return cls(lib_key, collection_id)
         except (ValueError, TypeError) as error:
             raise InvalidKeyError(cls, serialized) from error
 
@@ -1683,7 +1683,7 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
         lct:org:lib:ct-type:ct-id
     """
     CANONICAL_NAMESPACE = 'lct'  # "Library Container"
-    KEY_FIELDS = ('library_key', 'container_type', 'container_id')
+    KEY_FIELDS = ('lib_key', 'container_type', 'container_id')
     container_type: str
     container_id: str
 
@@ -1693,17 +1693,17 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     # Allow container IDs to contian unicode characters
     CONTAINER_ID_REGEXP = re.compile(r'^[\w\-.]+$', flags=re.UNICODE)
 
-    def __init__(self, library_key: LibraryLocatorV2, container_type: str, container_id: str):
+    def __init__(self, lib_key: LibraryLocatorV2, container_type: str, container_id: str):
         """
         Construct a CollectionLocator
         """
-        if not isinstance(library_key, LibraryLocatorV2):
-            raise TypeError("library_key must be a LibraryLocatorV2")
+        if not isinstance(lib_key, LibraryLocatorV2):
+            raise TypeError("lib_key must be a LibraryLocatorV2")
 
         self._check_key_string_field("container_type", container_type)
         self._check_key_string_field("container_id", container_id, regexp=self.CONTAINER_ID_REGEXP)
         super().__init__(
-            library_key=library_key,
+            lib_key=lib_key,
             container_type=container_type,
             container_id=container_id,
         )
@@ -1713,15 +1713,15 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
         """
         The organization that this Container belongs to.
         """
-        return self.library_key.org
+        return self.lib_key.org
 
     def _to_string(self) -> str:
         """
         Serialize this key as a string
         """
         return ":".join((
-            self.library_key.org,
-            self.library_key.slug,
+            self.lib_key.org,
+            self.lib_key.slug,
             self.container_type,
             self.container_id
         ))
@@ -1733,7 +1733,7 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
         """
         try:
             (org, lib_slug, container_type, container_id) = serialized.split(':')
-            library_key = LibraryLocatorV2(org, lib_slug)
-            return cls(library_key, container_type, container_id)
+            lib_key = LibraryLocatorV2(org, lib_slug)
+            return cls(lib_key, container_type, container_id)
         except (ValueError, TypeError) as error:
             raise InvalidKeyError(cls, serialized) from error

--- a/opaque_keys/edx/tests/test_collection_locators.py
+++ b/opaque_keys/edx/tests/test_collection_locators.py
@@ -29,22 +29,22 @@ class TestLibraryCollectionLocator(LocatorBaseTest):
         org = 'TestX'
         lib = 'LibraryX'
         code = 'test-problem-bank'
-        library_key = LibraryLocatorV2(org=org, slug=lib)
-        coll_key = LibraryCollectionLocator(library_key=library_key, collection_id=code)
-        library_key = coll_key.library_key
+        lib_key = LibraryLocatorV2(org=org, slug=lib)
+        coll_key = LibraryCollectionLocator(lib_key=lib_key, collection_id=code)
+        lib_key = coll_key.lib_key
         self.assertEqual(str(coll_key), "lib-collection:TestX:LibraryX:test-problem-bank")
         self.assertEqual(coll_key.org, org)
         self.assertEqual(coll_key.collection_id, code)
-        self.assertEqual(library_key.org, org)
-        self.assertEqual(library_key.slug, lib)
+        self.assertEqual(lib_key.org, org)
+        self.assertEqual(lib_key.slug, lib)
 
     def test_coll_key_constructor_bad_ids(self):
-        library_key = LibraryLocatorV2(org="TestX", slug="lib1")
+        lib_key = LibraryLocatorV2(org="TestX", slug="lib1")
 
         with self.assertRaises(ValueError):
-            LibraryCollectionLocator(library_key=library_key, collection_id='usage-!@#{$%^&*}')
+            LibraryCollectionLocator(lib_key=lib_key, collection_id='usage-!@#{$%^&*}')
         with self.assertRaises(TypeError):
-            LibraryCollectionLocator(library_key=None, collection_id='usage')
+            LibraryCollectionLocator(lib_key=None, collection_id='usage')
 
     def test_coll_key_from_string(self):
         org = 'TestX'
@@ -52,12 +52,12 @@ class TestLibraryCollectionLocator(LocatorBaseTest):
         code = 'test-problem-bank'
         str_key = f"lib-collection:{org}:{lib}:{code}"
         coll_key = LibraryCollectionLocator.from_string(str_key)
-        library_key = coll_key.library_key
+        lib_key = coll_key.lib_key
         self.assertEqual(str(coll_key), str_key)
         self.assertEqual(coll_key.org, org)
         self.assertEqual(coll_key.collection_id, code)
-        self.assertEqual(library_key.org, org)
-        self.assertEqual(library_key.slug, lib)
+        self.assertEqual(lib_key.org, org)
+        self.assertEqual(lib_key.slug, lib)
 
     def test_coll_key_invalid_from_string(self):
         with self.assertRaises(InvalidKeyError):

--- a/opaque_keys/edx/tests/test_container_locators.py
+++ b/opaque_keys/edx/tests/test_container_locators.py
@@ -30,34 +30,34 @@ class TestLibraryContainerLocator(LocatorBaseTest):
         lib = 'LibraryX'
         container_type = 'unit'
         container_id = 'test-container'
-        library_key = LibraryLocatorV2(org=org, slug=lib)
+        lib_key = LibraryLocatorV2(org=org, slug=lib)
         container_key = LibraryContainerLocator(
-            library_key=library_key,
+            lib_key=lib_key,
             container_type=container_type,
             container_id=container_id,
         )
-        library_key = container_key.library_key
+        lib_key = container_key.lib_key
         self.assertEqual(str(container_key), "lct:TestX:LibraryX:unit:test-container")
         self.assertEqual(container_key.org, org)
         self.assertEqual(container_key.container_type, container_type)
         self.assertEqual(container_key.container_id, container_id)
-        self.assertEqual(library_key.org, org)
-        self.assertEqual(library_key.slug, lib)
+        self.assertEqual(lib_key.org, org)
+        self.assertEqual(lib_key.slug, lib)
 
     def test_key_constructor_bad_ids(self):
-        library_key = LibraryLocatorV2(org="TestX", slug="lib1")
+        lib_key = LibraryLocatorV2(org="TestX", slug="lib1")
 
         with self.assertRaises(TypeError):
-            LibraryContainerLocator(library_key=None, container_type='unit', container_id='usage')
+            LibraryContainerLocator(lib_key=None, container_type='unit', container_id='usage')
 
         with self.assertRaises(ValueError):
-            LibraryContainerLocator(library_key=library_key, container_type='unit', container_id='usage-!@#{$%^&*}')
+            LibraryContainerLocator(lib_key=lib_key, container_type='unit', container_id='usage-!@#{$%^&*}')
 
     def test_key_constructor_bad_type(self):
-        library_key = LibraryLocatorV2(org="TestX", slug="lib1")
+        lib_key = LibraryLocatorV2(org="TestX", slug="lib1")
 
         with self.assertRaises(ValueError):
-            LibraryContainerLocator(library_key=library_key, container_type='unit-!@#{$%^&*}', container_id='usage')
+            LibraryContainerLocator(lib_key=lib_key, container_type='unit-!@#{$%^&*}', container_id='usage')
 
     def test_key_from_string(self):
         org = 'TestX'
@@ -66,10 +66,10 @@ class TestLibraryContainerLocator(LocatorBaseTest):
         container_id = 'test-container'
         str_key = f"lct:{org}:{lib}:{container_type}:{container_id}"
         container_key = LibraryContainerLocator.from_string(str_key)
-        library_key = container_key.library_key
+        lib_key = container_key.lib_key
         self.assertEqual(str(container_key), str_key)
         self.assertEqual(container_key.org, org)
         self.assertEqual(container_key.container_type, container_type)
         self.assertEqual(container_key.container_id, container_id)
-        self.assertEqual(library_key.org, org)
-        self.assertEqual(library_key.slug, lib)
+        self.assertEqual(lib_key.org, org)
+        self.assertEqual(lib_key.slug, lib)


### PR DESCRIPTION
As discovered in https://github.com/openedx/edx-platform/commit/24ec901b0c261f017eb7f760698598b57d261d57#r155569458 some of our new library opaque keys use "lib_key" for the parent library key and others use "library_key". We should make this consistent before Teak.

The older v1 library keys continue to use `library_key` but I don't care as much if they're inconsistent. It's more important that the v2 keys are self-consistent. **This way, whether we have a key to a container or a to an XBlock, we can use .lib_key to get the library key**.

Dependencies: This is safe to merge anytime _after_ the edx-platform PR https://github.com/openedx/edx-platform/pull/36563 has merged. That PR can be merged anytime.

Private ref: FAL-4147