### PR TITLE
feat: Add context_key property to library collection/container keys

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+# Unreleased
+
+* Added ``context_key`` to LibraryContainerLocator and LibraryCollectionLocator
+
 # 2.13.0
 
 * Breaking change to the new LibraryContainerLocator and

--- a/opaque_keys/edx/keys.py
+++ b/opaque_keys/edx/keys.py
@@ -114,6 +114,15 @@ class LibraryItemKey(OpaqueKey):
     def library_key(self):
         return self.lib_key
 
+    @property
+    @abstractmethod
+    def context_key(self) -> LearningContextKey:
+        """
+        Get the learning context key (LearningContextKey) for this item.
+        Will be a library key in this case.
+        """
+        raise NotImplementedError()
+
 
 class DefinitionKey(OpaqueKey):
     """

--- a/opaque_keys/edx/locator.py
+++ b/opaque_keys/edx/locator.py
@@ -1675,6 +1675,10 @@ class LibraryCollectionLocator(CheckFieldMixin, LibraryItemKey):
         except (ValueError, TypeError) as error:
             raise InvalidKeyError(cls, serialized) from error
 
+    @property
+    def context_key(self) -> LibraryLocatorV2:
+        return self.lib_key
+
 
 class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
     """
@@ -1713,6 +1717,10 @@ class LibraryContainerLocator(CheckFieldMixin, LibraryItemKey):
         The organization that this Container belongs to.
         """
         return self.lib_key.org
+
+    @property
+    def context_key(self) -> LibraryLocatorV2:
+        return self.lib_key
 
     def _to_string(self) -> str:
         """

--- a/opaque_keys/edx/tests/test_collection_locators.py
+++ b/opaque_keys/edx/tests/test_collection_locators.py
@@ -52,12 +52,14 @@ class TestLibraryCollectionLocator(LocatorBaseTest):
         code = 'test-problem-bank'
         str_key = f"lib-collection:{org}:{lib}:{code}"
         coll_key = LibraryCollectionLocator.from_string(str_key)
+        assert str(coll_key) == str_key
+        assert coll_key.org == org
+        assert coll_key.collection_id == code
         lib_key = coll_key.lib_key
-        self.assertEqual(str(coll_key), str_key)
-        self.assertEqual(coll_key.org, org)
-        self.assertEqual(coll_key.collection_id, code)
-        self.assertEqual(lib_key.org, org)
-        self.assertEqual(lib_key.slug, lib)
+        assert isinstance(lib_key, LibraryLocatorV2)
+        assert lib_key.org == org
+        assert lib_key.slug == lib
+        assert coll_key.context_key == lib_key
 
     def test_coll_key_invalid_from_string(self):
         with self.assertRaises(InvalidKeyError):

--- a/opaque_keys/edx/tests/test_container_locators.py
+++ b/opaque_keys/edx/tests/test_container_locators.py
@@ -66,10 +66,12 @@ class TestLibraryContainerLocator(LocatorBaseTest):
         container_id = 'test-container'
         str_key = f"lct:{org}:{lib}:{container_type}:{container_id}"
         container_key = LibraryContainerLocator.from_string(str_key)
+        assert str(container_key) == str_key
+        assert container_key.org == org
+        assert container_key.container_type == container_type
+        assert container_key.container_id == container_id
         lib_key = container_key.lib_key
-        self.assertEqual(str(container_key), str_key)
-        self.assertEqual(container_key.org, org)
-        self.assertEqual(container_key.container_type, container_type)
-        self.assertEqual(container_key.container_id, container_id)
-        self.assertEqual(lib_key.org, org)
-        self.assertEqual(lib_key.slug, lib)
+        assert isinstance(lib_key, LibraryLocatorV2)
+        assert lib_key.org == org
+        assert lib_key.slug == lib
+        assert container_key.context_key == lib_key


### PR DESCRIPTION
Any key for a content item (e.g. an XBlock, a container, a collection) that's in a library or course should have the `.context_key` property to get the key of the learning context (course or library) that contains it.